### PR TITLE
(feature) Allow for customisation of SSH MaxStartups and MaxSessions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,10 @@ allowed_users: ali saleh baker root #Put None or list of users space between eac
 allowed_groups: None
 deny_users: None
 deny_groups: None
+## 5.2.21 Ensure SSH MaxStartups is configured
+ssh_max_Startups: "10:30:100"
+# 5.2.22 Ensure SSH MaxSessions is limited
+ssh_max_sessions: 10
 # 5.4.1.1 Ensure password expiration is 365 days or less
 pass_expire_in_days: 300
 pass_warn_age: 7

--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -786,7 +786,7 @@
     - name: 1.7.1.2 Ensure AppArmor is enabled in the bootloader configuration | reload
       shell: |
         update-grub
-      when: output_1_7_1_2
+      when: output_1_7_1_2  | bool
   tags:
     - section1
     - level_1_server

--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -448,12 +448,12 @@
     - 5.2.20
 # 5.2.21 Ensure SSH MaxStartups is configured
 # To protect a system from denial of service due to a large number of pending authentication connection attempts, use the rate limiting function of MaxStartups to protect availability of sshd logins and prevent overwhelming the daemon.
-- name: 5.2.21 Ensure SSH MaxStartups is configured
+- name: "5.2.21 Ensure SSH MaxStartups is configured to {{ ssh_max_startups }}"
   lineinfile:
     state: present
     dest: /etc/ssh/sshd_config
     regexp: "^MaxStartups"
-    line: "MaxStartups 10:30:100"
+    line: "MaxStartups {{ ssh_max_startups }}"
   tags:
     - section5
     - level_1_server
@@ -461,12 +461,12 @@
     - 5.2.21
 # 5.2.22 Ensure SSH MaxSessions is limited
 # To protect a system from denial of service due to a large number of concurrent sessions, use the rate limiting function of MaxSessions to protect availability of sshd logins and prevent overwhelming the daemon.
-- name: 5.2.22 Ensure SSH MaxSessions is limited
+- name: "5.2.22 Ensure SSH MaxSessions is limited to {{ ssh_max_sessions }}"
   lineinfile:
     state: present
     dest: /etc/ssh/sshd_config
     regexp: "^MaxSessions"
-    line: "MaxSessions 10"
+    line: "MaxSessions {{ ssh_max_sessions }}"
   tags:
     - section5
     - level_1_server


### PR DESCRIPTION
- Instead of hardcoding the value in the playbook file (tests 5.2.21 and 5.2.22), it'd be better to allow the value to be configured in the main.yml file, fore easy customisation.

- Also resolves a warning in tasks/section_1_Initial_Setup.yaml 

Issue: alivx/CIS-Ubuntu-20.04-Ansible#6
