### PR TITLE
(feature) Allows configuration of SSH MACs and KexAlgorithms.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,10 @@ install_apparmor: true
 #Section 5
 #5.1.8 Ensure cron is restricted to authorized users
 allowd_hosts: "ALL: 0.0.0.0/0.0.0.0, 192.168.2.0/255.255.255.0"
+# 5.2.13 Ensure only strong MAC algorithms are used
+ssh_MACs: "hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256"
+# 5.2.14 Ensure only strong Key Exchange algorithms are used
+ssh_key_algorithms: "curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256"
 # 5.2.17 Ensure SSH access is limited
 allowed_users: ali saleh baker root #Put None or list of users space between each user
 allowed_groups: None

--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -313,7 +313,7 @@
     state: present
     dest: /etc/ssh/sshd_config
     regexp: "^MACs"
-    line: "MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256"
+    line: "MACs {{ ssh_MACs }}"
   tags:
     - section5
     - level_1_server
@@ -326,7 +326,7 @@
     state: present
     dest: /etc/ssh/sshd_config
     regexp: "^KexAlgorithms"
-    line: "KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256"
+    line: "KexAlgorithms {{ ssh_key_algorithms }}"
   tags:
     - section5
     - level_1_server


### PR DESCRIPTION
In some cases, hardening of ssh/scp should allow the explicit use of weaker protocols, for instance when other servers that connect to the hardened server don't possess certain strong protocols and as a consequence, can't connect amymore.

This can be implemented by allowing the MAC and KexAlgorithms to be defined/overwritten from the configuration.

For instance:
In `main.yml`:
```
ssh_MACs: "hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,_hmac-sha1-96_"

ssh_key_algorithms: "curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256,_diffie-hellman-group14-sha1_"
```

```
# 5.2.13 Ensure only strong MAC algorithms are used
# MD5 and 96-bit MAC algorithms are considered weak and have been shown to increase exploitability in SSH downgrade attacks. Weak algorithms continue to have a great deal of attention as a weak spot that can be exploited with expanded computing power. An attacker that breaks the algorithm could take advantage of a MiTM position to decrypt the SSH tunnel and capture credentials and information
- name: 5.2.13 Ensure only strong MAC algorithms are used
  lineinfile:
    state: present
    dest: /etc/ssh/sshd_config
    regexp: "^MACs"
    line: "MACs ${{ ssh_MACs }}"     <------------
  tags:
    - section5
    - level_1_server
    - level_1_workstation
    - 5.2.13

# 5.2.14 Ensure only strong Key Exchange algorithms are used
# Key exchange methods that are considered weak should be removed. A key exchange method may be weak because too few bits are used, or the hashing algorithm is considered too weak. Using weak algorithms could expose connections to man-in-the-middle attacks
- name: 5.2.14 Ensure only strong Key Exchange algorithms are used
  lineinfile:
    state: present
    dest: /etc/ssh/sshd_config
    regexp: "^KexAlgorithms"
    line: "KexAlgorithms ${{ ssh_key_algorithms }}   <------------
  tags:
    - section5
    - level_1_server
    - level_1_workstation
    - 5.2.14
```

Resolves alivx/CIS-Ubuntu-20.04-Ansible#9