### PR TITLE
(feature) [COTEF1901-104] Improved test 1.6.4 (coredump.conf)

### DIFF
--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -737,7 +737,10 @@
         state: present
         create: true
         insertbefore: "# End of file"
-
+    - name: 1.6.4 Ensure core dumps are restricted
+      apt:
+        name: systemd-coredump
+        state: present
     - name: 1.6.4 Ensure core dumps are restricted
       lineinfile:
         dest: /etc/systemd/coredump.conf
@@ -746,7 +749,6 @@
         state: present
         create: true
         insertbefore: "# End of file"
-
     - name: 1.6.4 Ensure core dumps are restricted
       lineinfile:
         dest: /etc/systemd/coredump.conf
@@ -755,11 +757,6 @@
         state: present
         create: true
         insertbefore: "# End of file"
-
-    - name: 1.6.4 Ensure core dumps are restricted
-      apt:
-        name: systemd-coredump
-        state: present
     - name: 1.6.4 Ensure core dumps are restricted | reload
       shell: systemctl daemon-reload
   tags:

--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -737,6 +737,25 @@
         state: present
         create: true
         insertbefore: "# End of file"
+
+    - name: 1.6.4 Ensure core dumps are restricted
+      lineinfile:
+        dest: /etc/systemd/coredump.conf
+        line: "Storage=none"
+        regexp: '(^#)?\s*Storage\s*='
+        state: present
+        create: true
+        insertbefore: "# End of file"
+
+    - name: 1.6.4 Ensure core dumps are restricted
+      lineinfile:
+        dest: /etc/systemd/coredump.conf
+        line: "ProcessSizeMax=0"
+        regexp: '(^#)?\s*ProcessSizeMax\s*='
+        state: present
+        create: true
+        insertbefore: "# End of file"
+
     - name: 1.6.4 Ensure core dumps are restricted
       apt:
         name: systemd-coredump


### PR DESCRIPTION
A few recommended settings in `/etc/coredump.conf` were omitted. This PR adds them, as per the recommendations:

```
Solution: Add the following line to /etc/security/limits.conf or a /etc/security/limits.d/* file:

* hard core 0

Set the following parameter in /etc/sysctl.conf or a /etc/sysctl.d/* file:

fs.suid_dumpable = 0

Run the following command to set the active kernel parameter:

# sysctl -w fs.suid_dumpable=0

If systemd-coredump is installed:         
edit /etc/systemd/coredump.conf and add/modify the following lines:   <-----------

Storage=none
ProcessSizeMax=0

Run the command:

systemctl daemon-reload
```