### PR TITLE
(feature) Improve motd message by allowing the use of an external template

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Defaults file for Auto-CIS-Ubuntu-Linux-20.04-LTS-Remediation
 
-# Section 1
+# Section 1 settings
 disable_cramfs: yes
 disable_freevxfs: yes
 disable_jffs2: yes
@@ -17,10 +17,12 @@ bootloader_credentials: { user: "root", password: "b00tl04derPwd" }
 # 1.5.3 Ensure authentication required for single user mode
 set_root_password: yes
 root_password: r00tP4ssw0rd
+## 1.8.1.4 Ensure permissions on /etc/motd are configured: allow for custom motd template (if the file doesn't exist, the
+## default template in files/templates/motd.j2 will be used)
+custom_motd_file_path: "{{ inventory_dir }}/custom_templates/motd_custom.txt"
 
 # Section 2 Settings
-
-#Setting for systemd-timesyncd
+##Setting for systemd-timesyncd
 enable_systemdtimesyncd: no #If you enable this make sure to disable NTP below, only one time service must be run in the server
 timesync_timezone: Etc/UTC
 timesync_fallback_ntp_hosts:
@@ -29,7 +31,7 @@ timesync_fallback_ntp_hosts:
   - 2.pool.ntp.org
   - 3.pool.ntp.org
 
-#Setting for NTP
+## Settings for NTP
 enableNTP: yes
 time_synchronization_package_name: ntp
 time_synchronization_servers:
@@ -42,7 +44,7 @@ time_synchronization_servers:
   - uri: "time4.google.com"
     config: "iburst"
 
-# Setting for chrony
+## Settings for chrony
 chronyEnable: no
 chrony_driftfile: /var/lib/chrony/chrony.drift
 chronyservers_preferred: []
@@ -79,12 +81,14 @@ remove_telnetclient: yes
 remove_LDAPclient: yes
 remove_RPC: yes
 
+
 # Section 3 Settings
 disable_wifi: False
 IPv6_is_enabled: Yes
 enable_firewall: yes
 list_of_ports_to_allow:
   - { rule: "allow", port: "8080", proto: "tcp" }
+
 
 # Section 4 Settings
 ## Ensure rsyslog is configured to send logs to a remote log host
@@ -104,7 +108,8 @@ space_left_action: email
 action_mail_acct: root
 grub_backlog_limit: 8192
 
-#Section 5
+
+# Section 5 settings
 ## 5.1.8 Ensure cron is restricted to authorized users
 allowd_hosts: "ALL: 0.0.0.0/0.0.0.0, 192.168.2.0/255.255.255.0"
 ## 5.2.13 Ensure only strong MAC algorithms are used
@@ -133,12 +138,13 @@ account_inactive: 30
 ## 5.4.5 Ensure default user shell timeout is 900 seconds or less
 shell_timeout_sec: 900
 
-# Section 6
+
+# Section 6 settings
 withoutOwnerFileDirOwner: root
 withoutGroupFilesDirGroup: root
 outputfiles: /root/ #Output dir of some command
 disable_autofs: true
 disable_usb: true
 install_apparmor: true
-# 6.2.7 Ensure users' dot files are not group or world accessible
+## 6.2.7 Ensure users' dot files are not group or world accessible
 fix_dot_file_permissions: yes

--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -748,7 +748,7 @@
 # overridden by the user.
 - name: 1.6.4 Ensure core dumps are restricted
   block:
-    - name: 1.6.4 Ensure core dumps are restricted
+    - name: 1.6.4 Ensure core dumps are restricted | sysctl
       sysctl:
         name: fs.suid_dumpable
         value: "0"
@@ -756,7 +756,7 @@
         reload: true
         sysctl_set: true
         ignoreerrors: true
-    - name: 1.6.4 Ensure core dumps are restricted
+    - name: 1.6.4 Ensure core dumps are restricted | limits.conf
       lineinfile:
         dest: /etc/security/limits.conf
         line: "*                hard    core            0"
@@ -764,11 +764,11 @@
         state: present
         create: true
         insertbefore: "# End of file"
-    - name: 1.6.4 Ensure core dumps are restricted
+    - name: 1.6.4 Ensure core dumps are restricted | apt
       apt:
         name: systemd-coredump
         state: present
-    - name: 1.6.4 Ensure core dumps are restricted
+    - name: 1.6.4 Ensure core dumps are restricted | coredump.conf
       lineinfile:
         dest: /etc/systemd/coredump.conf
         line: "Storage=none"
@@ -776,7 +776,7 @@
         state: present
         create: true
         insertbefore: "# End of file"
-    - name: 1.6.4 Ensure core dumps are restricted
+    - name: 1.6.4 Ensure core dumps are restricted | coredump.conf
       lineinfile:
         dest: /etc/systemd/coredump.conf
         line: "ProcessSizeMax=0"

--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -748,7 +748,7 @@
 # overridden by the user.
 - name: 1.6.4 Ensure core dumps are restricted
   block:
-    - name: 1.6.4 Ensure core dumps are restricted | sysctl
+    - name: 1.6.4 Ensure core dumps are restricted
       sysctl:
         name: fs.suid_dumpable
         value: "0"
@@ -756,7 +756,7 @@
         reload: true
         sysctl_set: true
         ignoreerrors: true
-    - name: 1.6.4 Ensure core dumps are restricted | limits.conf
+    - name: 1.6.4 Ensure core dumps are restricted
       lineinfile:
         dest: /etc/security/limits.conf
         line: "*                hard    core            0"
@@ -764,11 +764,11 @@
         state: present
         create: true
         insertbefore: "# End of file"
-    - name: 1.6.4 Ensure core dumps are restricted | apt
+    - name: 1.6.4 Ensure core dumps are restricted
       apt:
         name: systemd-coredump
         state: present
-    - name: 1.6.4 Ensure core dumps are restricted | coredump.conf
+    - name: 1.6.4 Ensure core dumps are restricted
       lineinfile:
         dest: /etc/systemd/coredump.conf
         line: "Storage=none"
@@ -776,7 +776,7 @@
         state: present
         create: true
         insertbefore: "# End of file"
-    - name: 1.6.4 Ensure core dumps are restricted | coredump.conf
+    - name: 1.6.4 Ensure core dumps are restricted
       lineinfile:
         dest: /etc/systemd/coredump.conf
         line: "ProcessSizeMax=0"
@@ -824,6 +824,7 @@
         dest: /etc/default/grub
         regexp: '^(GRUB_CMDLINE_LINUX=(?!.*apparmor)\"[^\"]*)(\".*)'
         replace: '\1 apparmor=1 security=apparmor\2'
+        follow: true
       register: output_1_7_1_2
     - name: 1.7.1.2 Ensure AppArmor is enabled in the bootloader configuration | reload
       shell: |
@@ -867,14 +868,21 @@
 # developing software for a particular OS platform. If mingetty(8) supports the following
 # options, they display operating system information: \m - machine architecture \r -
 # operating system release \s - operating system name \v - operating system version
+
+# We allow overwriting the default motd message (contained in files/templates/motd.j2) by a custom template, whose path
+# has to be defined in the variable "custom_motd_file_path".
 - name: 1.8.1.1 Ensure message of the day is configured properly
     1.8.1.4 Ensure permissions on /etc/motd are configured"
   template:
-    src: files/templates/motd.j2
+    src: "{{ lookup('first_found', motd, errors='ignore') }}"
     dest: /etc/motd
     owner: root
     group: root
     mode: "u-x,go-wx"
+  vars:
+    - motd:
+      - "{{ custom_motd_file_path }}"
+      - "files/templates/motd.j2"
   tags:
     - section1
     - level_1_server


### PR DESCRIPTION
Sometimes it's needed to have different templates for different customers. This feature allows for overwriting the default template (in `files/templates/motd.j2`) with an external file, by setting a variable pointing to that file. 

If the file doesn't exist, the default template will be used.