### PR TITLE
(bugfix) [3.5.1.7] 'enable_firewall' flag applied to all 'ufw' tasks

### DIFF
--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -593,16 +593,11 @@
         ufw default deny incoming
         ufw default allow outgoing
         ufw default deny routed
+    - name: Enable UFW
+      ufw:
+        state: enabled
+        policy: allow
   when: enable_firewall
-  tags:
-    - section3
-    - level_1_server
-    - level_1_workstation
-    - 3.5.1.7
-- name: Enable UFW
-  ufw:
-    state: enabled
-    policy: allow
   tags:
     - section3
     - level_1_server


### PR DESCRIPTION
`enable_firewall` should apply to all ufw rules in task 3.5.1.7

The following task didn't have the "when: enable_firewall" condition set.
```
    - name: Enable UFW
      ufw:
        state: enabled
        policy: allow
```