### PR TITLE
(bugfix) [3.3.1] Only execute ipv6 commands when 'IPv6_is_enabled' is set

### DIFF
--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -133,6 +133,8 @@
         sysctl -w net.ipv6.conf.all.accept_source_route=0
         sysctl -w net.ipv6.conf.default.accept_source_route=0
         sysctl -w net.ipv6.route.flush=1
+      when:
+        - IPv6_is_enabled
   tags:
     - section3
     - level_1_server


### PR DESCRIPTION
The following task might fail when ipv6 is not enabled (`IPv6_is_enabled`):

```
   - name: 3.3.1 Ensure source routed packets are not accepted | ipv6 load"
      shell: |
        sysctl -w net.ipv6.conf.all.accept_source_route=0
        sysctl -w net.ipv6.conf.default.accept_source_route=0
        sysctl -w net.ipv6.route.flush=1
```