### PR TITLE
(bugfix) [3.3.9] Only execute ipv6 commands when 'IPv6_is_enabled' is set

### DIFF
--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -346,12 +346,12 @@
       with_items:
         - { name: net.ipv6.conf.all.accept_ra, value: 0 }
         - { name: net.ipv6.conf.default.accept_ra, value: 0 }
-      when: IPv6_is_enabled
     - name: 3.3.9 Ensure IPv6 router advertisements are not accepted | load
       shell: |
         sysctl -w net.ipv6.conf.all.accept_ra=0
         sysctl -w net.ipv6.conf.default.accept_ra=0
         sysctl -w net.ipv6.route.flush=1
+  when: IPv6_is_enabled
   tags:
     - section3
     - level_1_server


### PR DESCRIPTION
The following task might fail if no ipv6 is provided, so only execute it when `IPv6_is_enabled` flag is set.
```
    - name: 3.3.9 Ensure IPv6 router advertisements are not accepted | load	    - name: 3.3.9 Ensure IPv6 router advertisements are not accepted | load
      shell: |	      shell: |
        sysctl -w net.ipv6.conf.all.accept_ra=0	        sysctl -w net.ipv6.conf.all.accept_ra=0
        sysctl -w net.ipv6.conf.default.accept_ra=0	        sysctl -w net.ipv6.conf.default.accept_ra=0
        sysctl -w net.ipv6.route.flush=1
 ``` 