### PR TITLE
(bugfix) [5.4.1.1] Task shouldn't fail if user in list doesn't exist

### DIFF
--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -593,6 +593,7 @@
     - name: 5.4.1.1 Ensure password expiration is 365 days or less | chage --warndays
       command: "chage --warndays {{ pass_warn_age }} {{ item }}"
       with_items: "{{ list_of_os_users }}"
+  ignore_errors: yes
   tags:
     - section5
     - level_1_server


### PR DESCRIPTION
If a user mentioned in the list `list_of_os_users` doesn't exist in the destination server for task 5.4.1.1, the task should not abort but simply continue with other users:

```
- name: 5.4.1.1 Ensure password expiration is 365 days or less\
    5.4.1.2 Ensure minimum days between password changes is configured\n
    5.4.1.3 Ensure password expiration warning days is 7 or more"
  block:
    - name: 5.4.1.1 Ensure password expiration is 365 days or less | PASS_MAX_DAYS
      lineinfile:
        state: present
        dest: /etc/login.defs
        regexp: "^PASS_MAX_DAYS"
        line: "PASS_MAX_DAYS {{ pass_expire_in_days }}"
    - name: 5.4.1.1 Ensure password expiration is 365 days or less | PASS_MIN_DAYS
      lineinfile:
        state: present
        dest: /etc/login.defs
        regexp: "^PASS_MIN_DAYS"
        line: "PASS_MIN_DAYS {{ pass_min_days }}"
    - name: 5.4.1.1 Ensure password expiration is 365 days or less | PASS_WARN_AGE
      lineinfile:
        state: present
        dest: /etc/login.defs
        regexp: "^PASS_WARN_AGE"
        line: "PASS_WARN_AGE {{ pass_warn_age }}"
    - name: 5.4.1.1 Ensure password expiration is 365 days or less | chage
      command: "chage --maxdays {{ pass_expire_in_days }} {{ item }}"
      with_items: "{{ list_of_os_users }}"
    - name: 5.4.1.1 Ensure password expiration is 365 days or less | chage --mindays
      command: "chage --mindays {{ pass_min_days }} {{ item }}"
      with_items: "{{ list_of_os_users }}"
    - name: 5.4.1.1 Ensure password expiration is 365 days or less | chage --warndays
      command: "chage --warndays {{ pass_warn_age }} {{ item }}"
      with_items: "{{ list_of_os_users }}"
```