### PR TITLE
(bugfix) [5.4.1.4] Task shouldn't fail if user in list doesn't exist

### DIFF
--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -603,11 +603,12 @@
 # 5.4.1.4 Ensure inactive password lock is 30 days or less
 - name: 5.4.1.4 Ensure inactive password lock is 30 days or less
   block:
-    - name: 5.4.1.4 Ensure inactive password lock is 30g1 days or less | useradd
+    - name: 5.4.1.4 Ensure inactive password lock is 30 days or less | useradd
       command: "useradd -D -f {{ account_inactive }}"
     - name: 5.4.1.4 Ensure inactive password lock is 30 days or less | useradd
       command: "chage --inactive {{ account_inactive }} {{ item }}"
       with_items: "{{ list_of_os_users }}"
+  ignore_errors: yes
   tags:
     - section5
     - level_1_server


### PR DESCRIPTION
The following task should not fail if a user in the list `list_of_os_users` doesn't exist, instead it should continue with the next user in the list.

```
- name: 5.4.1.4 Ensure inactive password lock is 30 days or less
  block:
    - name: 5.4.1.4 Ensure inactive password lock is 30 days or less | useradd
      command: "useradd -D -f {{ account_inactive }}"
    - name: 5.4.1.4 Ensure inactive password lock is 30 days or less | useradd
      command: "chage --inactive {{ account_inactive }} {{ item }}"
      with_items: "{{ list_of_os_users }}"

```