### PR TITLE
(bugfix) [5.5.4] Remove readonly flags, throwing errors in shell, on TMOUT variable

### DIFF
--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -718,21 +718,21 @@
         dest: /etc/bash.bashrc
         create: true
         regexp: "^TMOUT="
-        line: "TMOUT={{ shell_timeout_sec }} ; readonly TMOUT ; export TMOUT"
+        line: "TMOUT={{ shell_timeout_sec }} ; export TMOUT"
     - name: 5.4.5 Ensure default user shell timeout is 900 seconds or less | /etc/profile
       lineinfile:
         state: present
         dest: /etc/profile
         create: true
         regexp: "^TMOUT="
-        line: "TMOUT={{ shell_timeout_sec }} ; readonly TMOUT ; export TMOUT"
+        line: "TMOUT={{ shell_timeout_sec }} ; export TMOUT"
     - name: 5.4.5 Ensure default user shell timeout is 900 seconds or less | /etc/profile.d/timeout.sh
       lineinfile:
         state: present
         dest: /etc/profile.d/tmout.sh
         create: true
         regexp: "^TMOUT="
-        line: "TMOUT={{ shell_timeout_sec }} ; readonly TMOUT ; export TMOUT"
+        line: "TMOUT={{ shell_timeout_sec }} ; export TMOUT"
   tags:
     - section5
     - level_1_server


### PR DESCRIPTION
Setting the TMOUT variable READONLY throws errors when entering the shell, because once set _readonly_, it's consecutively modified from within the other scrips
```
-bash: TMOUT: readonly variable
```