### PR TITLE
(feature) Avoids AIDE installation waiting eternally for input

### DIFF
--- a/files/1.4.1.txt
+++ b/files/1.4.1.txt
@@ -26,4 +26,5 @@
 !/var/lib/vnstat/*
 !/var/log.*
 !/var/spool/.*
+!/var/lib/lxcfs/cgroup/
 !/var/lib/docker/

--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -562,7 +562,7 @@
       loop: "{{ aide_exclude_paths }}"
       when: (aide_exclude_paths is defined) and (aide_exclude_paths| length > 0)
     - name: Configure AIDE as appropriate for your environment | aideinit
-      command: aideinit
+      command: aideinit --yes --force
     - name: Configure AIDE as appropriate for your environment | aideinit db
       shell: |
         mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db


### PR DESCRIPTION
- Added options so that the execution doesn't get stuck on questions:

```
Overwrite existing /var/lib/aide/aide.db.new [Yn]? Y
Overwrite /var/lib/aide/aide.db [yN]? y
```

- Also added exclusion of directory "/var/lib/lxcfs/cgroup/"; it throws a lot of errors during the checks, example:

```
do_md(): open() for /var/lib/lxcfs/cgroup/memory/system.slice/systemd-modules-load.service/memory.pressure_level failed: Permission denied
```
 
Finally, I am not sure why the following task is needed:
```
    - name: Configure AIDE as appropriate for your environment | aideinit db
      shell: |
        mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db
```
