### PR TITLE
(feature) Allows for simplifying AIDE checksums

### DIFF
--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -554,6 +554,13 @@
       copy:
         src: "files/1.4.1.txt"
         dest: "/etc/aide/aide.conf.d/00_local_excludes"
+    - name: Simplify AIDE checksums
+      lineinfile:
+        regexp: '^Checksums.*='
+        line: "Checksums = {{ aide_checksums }}"
+        path: "/etc/aide/aide.conf"
+        state: present
+      when: (aide_checksums is defined) and (aide_checksums| length > 0)
     - name: Add extra AIDE exclude paths
       lineinfile:
         line: "{{ item }}"


### PR DESCRIPTION
The default AIDE checksums might be a bit of overkill. This feature allows you to set a variable 
```
aide_checksums: "sha512"
```
so that only this checksum is executed.