### PR TITLE
Rename diy tag to manual

### DIFF
--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -273,7 +273,7 @@
     - level_1_server
     - level_1_workstation
     - 1.1.10
-    - diy
+    - manual
 # 1.1.11 Ensure separate partition exists for /var/tmp
 # 1.1.12 Ensure nodev option set on /var/tmp partition
 # 1.1.13 Ensure nosuid option set on /var/tmp partition
@@ -310,7 +310,7 @@
     - level_2_server
     - level_2_workstation
     - 1.1.15
-    - diy
+    - manual
 # 1.1.16 Ensure separate partition exists for /var/log/audit
 - name: 1.1.16 Ensure separate partition exists for /var/log/audit
   debug:
@@ -320,7 +320,7 @@
     - level_6_server
     - level_6_workstation
     - 1.1.16
-    - diy
+    - manual
 # 1.1.17 Ensure separate partition exists for /home
 - name: 1.1.17 Ensure separate partition exists for /home
   debug:
@@ -330,7 +330,7 @@
     - level_2_server
     - level_2_workstation
     - 1.1.17
-    - diy
+    - manual
 # 1.1.18 Ensure nodev option set on /home partition
 - name: 1.1.18 Ensure nodev option set on /home partition
   debug:
@@ -340,7 +340,7 @@
     - level_1_server
     - level_1_workstation
     - 1.1.18
-    - diy
+    - manual
 # 1.1.19 Ensure nodev option set on removable media partitions
 - name: 1.1.19 Ensure nodev option set on removable media partitions
   debug:
@@ -350,7 +350,7 @@
     - level_1_server
     - level_1_workstation
     - 1.1.19
-    - diy
+    - manual
 # 1.1.20 Ensure nosuid option set on removable media partitions
 - name: 1.1.20 Ensure nosuid option set on removable media partitions
   debug:
@@ -360,7 +360,7 @@
     - level_1_server
     - level_1_workstation
     - 1.1.20
-    - diy
+    - manual
 # 1.1.21 Ensure noexec option set on removable media partitions
 - name: 1.1.21 Ensure noexec option set on removable media partitions
   debug:
@@ -370,7 +370,7 @@
     - level_1_server
     - level_1_workstation
     - 1.1.21
-    - diy
+    - manual
 # 1.1.22 Ensure sticky bit is set on all world-writable directories
 - name: 1.1.22 Ensure sticky bit is set on all world-writable directories
   block:
@@ -474,7 +474,7 @@
     - level_1_server
     - level_1_workstation
     - 1.2.2
-    - diy
+    - manual
 # 1.3 Configure sudo
 # sudo allows a permitted user to execute a command as the superuser or another user, as
 # specified by the security policy. The invoking user's real (not effective) user ID is used to

--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -457,6 +457,7 @@
     - level_1_server
     - level_1_workstation
     - 1.2.1
+    - manual
 # 1.2.2 Ensure GPG keys are configured
 # Most packages managers implement GPG key signing to verify package integrity during installation.
 # It is important to ensure that updates are obtained from a valid source to protect against

--- a/tasks/section_2_Services.yaml
+++ b/tasks/section_2_Services.yaml
@@ -507,4 +507,4 @@
     - section2
     - level_1_server
     - level_1_workstation
-    - diy
+    - manual

--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -637,7 +637,7 @@
     - level_1_server
     - level_1_workstation
     - 5.4.1.5
-    - diy
+    - manual
 # 5.4.2 Ensure system accounts are secured
 - name: 5.4.2 Ensure system accounts are secured
   block:
@@ -756,7 +756,7 @@
     - level_1_server
     - level_1_workstation
     - _5.5
-    - diy
+    - manual
 # 5.6 Ensure access to the su command is restricted
 # Restricting the use of su , and using sudo in its place, provides system administrators better control of the escalation of user privileges to execute privileged commands. The sudo utility also provides a better logging and audit mechanism, as it can log each command executed via sudo , whereas su can only record that a user executed the su program.
 - name: 5.6 Ensure access to the su command is restricted

--- a/tasks/section_6_System_Maintenance.yaml
+++ b/tasks/section_6_System_Maintenance.yaml
@@ -17,7 +17,7 @@
     - level_1_server
     - level_1_workstation
     - 6.1.1
-    - diy
+    - manual
 # 6.1.2 Ensure permissions on /etc/passwd are configured
 - name: 6.1.2 Ensure permissions on /etc/passwd are configured
   file:
@@ -197,7 +197,7 @@
     - level_1_server
     - level_1_workstation
     - 6.1.13
-    - diy
+    - manual
 # 6.1.14 Audit SGID executables
 - name: 6.1.14 Audit SGID executables
   block:
@@ -218,7 +218,7 @@
     - level_1_server
     - level_1_workstation
     - 6.1.14
-    - diy
+    - manual
 # 6.2 User and Group Settings
 # 6.2.1 Ensure password fields are not empty
 - name: 6.2.1 Ensure password fields are not empty
@@ -243,7 +243,7 @@
     - level_1_server
     - level_1_workstation
     - 6.2.1
-    - diy
+    - manual
 # 6.2.2 Ensure root is the only UID 0 account
 - name: 6.2.2 Ensure root is the only UID 0 account
   block:
@@ -266,7 +266,7 @@
     - level_1_server
     - level_1_workstation
     - 6.2.2
-    - diy
+    - manual
 # 6.2.3 Ensure root PATH Integrity
 - name: 6.2.3 Ensure root PATH Integrity
   block:
@@ -282,7 +282,7 @@
     - level_1_server
     - level_1_workstation
     - 6.2.3
-    - diy
+    - manual
 # 6.2.4 Ensure all users' home directories exist
 - name: 6.2.4 Ensure all users' home directories exist
   block:
@@ -381,7 +381,7 @@
     - level_1_server
     - level_1_workstation
     - 6.2.7
-    - diy
+    - manual
 # 6.2.8 Ensure no users have .forward files
 - name: 6.2.8 Ensure no users have .forward files
   block:
@@ -397,7 +397,7 @@
     - level_1_server
     - level_1_workstation
     - 6.2.8
-    - diy
+    - manual
 # 6.2.9 Ensure no users have .netrc files
 - name: 6.2.9 Ensure no users have .netrc files
   block:
@@ -413,7 +413,7 @@
     - level_1_server
     - level_1_workstation
     - 6.2.9
-    - diy
+    - manual
 # 6.2.10 Ensure users' .netrc Files are not group or world accessible
 - name: 6.2.10 Ensure users' .netrc Files are not group or world accessible
   block:
@@ -429,7 +429,7 @@
     - level_1_server
     - level_1_workstation
     - 6.2.10
-    - diy
+    - manual
 # 6.2.11 Ensure no users have .rhosts files
 - name: 6.2.11 Ensure no users have .rhosts files
   block:
@@ -445,7 +445,7 @@
     - level_1_server
     - level_1_workstation
     - 6.2.11
-    - diy
+    - manual
 # 6.2.12 Ensure all groups in /etc/passwd exist in /etc/group
 - name: 6.2.12 Ensure all groups in /etc/passwd exist in /etc/group
   block:
@@ -467,7 +467,7 @@
     - level_1_server
     - level_1_workstation
     - 6.2.12
-    - diy
+    - manual
 # 6.2.13 Ensure no duplicate UIDs exist
 - name: 6.2.13 Ensure no duplicate UIDs exist
   block:
@@ -491,7 +491,7 @@
     - level_1_server
     - level_1_workstation
     - 6.2.13
-    - diy
+    - manual
 # 6.2.14 Ensure no duplicate GIDs exist
 - name: 6.2.14 Ensure no duplicate GIDs exist
   block:
@@ -510,7 +510,7 @@
     - level_1_server
     - level_1_workstation
     - 6.2.14
-    - diy
+    - manual
 # 6.2.15 Ensure no duplicate user names exist
 - name: 6.2.15 Ensure no duplicate user names exist
   block:
@@ -529,7 +529,7 @@
     - level_1_server
     - level_1_workstation
     - 6.2.15
-    - diy
+    - manual
 # 6.2.16 Ensure no duplicate group names exist
 - name: 6.2.16 Ensure no duplicate group names exist
   block:
@@ -548,7 +548,7 @@
     - level_1_server
     - level_1_workstation
     - 6.2.16
-    - diy
+    - manual
 # 6.2.17 Ensure shadow group is empty
 - name: 6.2.17 Ensure shadow group is empty
   block:
@@ -566,4 +566,4 @@
     - level_1_server
     - level_1_workstation
     - 6.2.17
-    - diy
+    - manual


### PR DESCRIPTION
As mentioned in issue #51 this branch implements renaming the `diy` tag to `manual` and adds the missing manual tag to `1.2.1 Ensure package manager repositories are configured`.