### PR TITLE
(bugfix) [1.1.1.7] Task shouldn't fail if module vfat is builtin.

### DIFF
--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -174,6 +174,7 @@
       modprobe:
         name: vfat
         state: absent
+  ignore_errors: yes
   when: disable_fat
   tags:
     - section1


### PR DESCRIPTION
Prevents error:

TASK [CIS-Ubuntu-20.04-Ansible : 1.1.1.7 Ensure mounting of FAT filesystems is limited | modprobe] ****************************************************************************************************************
fatal: [ansible01]: FAILED! => {"changed": false, "msg": "modprobe: FATAL: Module vfat is builtin.\n", "name": "vfat", "params": "", "rc": 1, "state": "absent", "stderr": "modprobe: FATAL: Module vfat is builtin.\n", "stderr_lines": ["modprobe: FATAL: Module vfat is builtin."], "stdout": "", "stdout_lines": []}
