### PR TITLE
feature: Purges autofs completely

### DIFF
--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -448,6 +448,7 @@
       apt:
         name: autofs
         state: absent
+        purge: yes
   when: disable_autofs
   tags:
     - section1


### PR DESCRIPTION
Some checking systems complain when the package isn't completely removed from the system, so I've added a purge.

```
cmd: /usr/bin/dpkg -s autofs 2>&1 expect: package 'autofs' is not installed system: Linux
```

Question: should we add this for all `state: absent` apt calls?