### PR TITLE
feature: Allows SSH root login from a certain list of IPs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -132,6 +132,8 @@ max_auth_tries: 4
 ssh_max_startups: "10:30:100"
 ## 5.2.22 Ensure SSH MaxSessions is limited
 ssh_max_sessions: 10
+## 5.3.10 Allow root logins for a certain list of IPs (default: no root login allowed), e.g. "192.168.10.10,192.168.1.0/24"
+ssh_root_login_ips: None
 ## 5.4.1.1 Ensure password expiration is 365 days or less
 pass_expire_in_days: 300
 pass_warn_age: 7

--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -320,16 +320,29 @@
 # 5.3.10 Ensure SSH root login is disabled
 # Disallowing root logins over SSH requires system admins to authenticate using their own individual account, then escalating to root via sudo or su . This in turn limits opportunity for non-repudiation and provides a clear audit trail in the event of a security incident
 - name: 5.3.10 Ensure SSH root login is disabled
-  lineinfile:
-    state: present
-    dest: /etc/ssh/sshd_config
-    regexp: "^PermitRootLogin"
-    line: "PermitRootLogin no"
+  block:
+    - name: "5.3.10 Ensure SSH root login is disabled: default"
+      lineinfile:
+        state: present
+        dest: /etc/ssh/sshd_config
+        regexp: "^PermitRootLogin .*"
+        line: "PermitRootLogin no"
+    - name: "5.3.10 Ensure SSH root login is disabled: remove root login for all existing IPs"
+      replace:
+        dest: /etc/ssh/sshd_config
+        regexp: "^Match Address.*\n.*PermitRootLogin.*$"
+    - name: "5.3.10 Ensure SSH root login is disabled: allow ssh root login from '{{ ssh_root_login_ips }}'"
+      lineinfile:
+        state: present
+        dest: /etc/ssh/sshd_config
+        regexp: "^Match Address.*\n*PermitRootLogin.*"
+        line: "Match Address {{ ssh_root_login_ips }}\n PermitRootLogin yes"
+      when: (ssh_root_login_ips != "None") and (ssh_root_login_ips|length > 0)
   tags:
-    - section5
-    - level_1_server
-    - level_1_workstation
-    - 5.3.10
+  - section5
+  - level_1_server
+  - level_1_workstation
+  - 5.3.10
 # 5.3.11 Ensure SSH PermitEmptyPasswords is disabled
 # Disallowing remote shell access to accounts that have an empty password reduces the probability of unauthorized access to the system
 - name: 5.3.11 Ensure SSH PermitEmptyPasswords is disabled


### PR DESCRIPTION
Allow root login from a certain list of IPs, only if the variable `ssh_root_login_ips` is not `None`

Example:

`ssh_root_login_ips: "192.168.10.10,192.168.1.0/24"`

In this case the `/etc/ssh/sshd_config` will contain a section:
``` 
Match Address 192.168.10.10,192.168.1.0/24
 PermitRootLogin yes
```