### PR TITLE
chore: Set group of /etc/shadow to root, for better compatibility

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -158,5 +158,8 @@ outputfiles: /root/ #Output dir of some command
 disable_autofs: true
 disable_usb: true
 install_apparmor: true
+## 6.1.6 Ensure permissions on /etc/shadow are configured
+etc_shadow_group: shadow
+
 ## 6.2.7 Ensure users' dot files are not group or world accessible
 fix_dot_file_permissions: yes

--- a/tasks/section_6_System_Maintenance.yaml
+++ b/tasks/section_6_System_Maintenance.yaml
@@ -68,11 +68,11 @@
     - 6.1.5
 
 # 6.1.6 Ensure permissions on /etc/shadow are configured
-- name: 6.1.6 Ensure permissions on /etc/shadow are configured
+- name: 6.1.6 Ensure permissions on /etc/shadow are configured, with group '{{ etc_shadow_group }}'
   file:
     dest: /etc/shadow
     owner: root
-    group: root
+    group: "{{ etc_shadow_group }}"
     mode: 0640
   tags:
     - section6

--- a/tasks/section_6_System_Maintenance.yaml
+++ b/tasks/section_6_System_Maintenance.yaml
@@ -72,7 +72,7 @@
   file:
     dest: /etc/shadow
     owner: root
-    group: shadow
+    group: root
     mode: 0640
   tags:
     - section6


### PR DESCRIPTION
CIS states for test 6.1.6:

> Run one of the following commands to set ownership of /etc/shadow to root and group to either root or shadow.

We used to set the group permissions to "shadow" but for better compatbility we should set it to "root".