### PR TITLE
6.2.7 include folders in hidden dot files search

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -160,3 +160,4 @@ disable_usb: true
 install_apparmor: true
 ## 6.2.7 Ensure users' dot files are not group or world accessible
 fix_dot_file_permissions: yes
+include_folders: false # Include folders as well as files

--- a/files/6_2_7_include_folders.sh
+++ b/files/6_2_7_include_folders.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+grep -E -v '^(halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
+    if [ ! -d "$dir" ]; then
+        echo "The home directory ($dir) of user $user does not exist."
+    else
+        for file in $dir/.[A-Za-z0-9]*; do
+            if [ ! -h "$file" -a "$file" ]; then
+                fileperm=$(ls -ld $file | cut -f1 -d" ")
+                if [ $(echo $fileperm | cut -c6) != "-" ]; then
+                    echo "Group Write permission set on file $file"
+                fi
+                if [ $(echo $fileperm | cut -c9) != "-" ]; then
+                    echo "Other Write permission set on file $file"
+                fi
+            fi
+        done
+    fi
+done

--- a/tasks/section_6_System_Maintenance.yaml
+++ b/tasks/section_6_System_Maintenance.yaml
@@ -367,6 +367,11 @@
     - name: 6.2.7 Ensure users dot files are not group or world writable | list
       script: 6_2_7.sh
       register: output_6_2_7
+      when: not include_folders
+    - name: 6.2.7 Ensure users dot files and folders are not group or world writable | list
+      script: 6_2_7_include_folders.sh
+      register: output_6_2_7
+      when: include_folders
     - name: 6.2.7 Ensure users' dot files are not group or world writable | save output
       copy:
         dest: "{{ outputfiles }}/6.2.7"


### PR DESCRIPTION
Task 6.2.7 only checks for hidden files in home directories, not folders. I'm unsure if this is the intended behavior but I added an option to use an alternate script that does check for folders as well.

Some vulnerability checking software such as Nessus checks if folders in home directory are not group or world writable with this expression:
`awk -F: '($1!~/(halt|sync|shutdown)/ && $7!~/^(/usr)?/sbin/nologin(/)?$/ && $7!~/(/usr)?/bin/false(/)?$/) { print $1 ' ' $6 }' | while read -r user dir; do if [ -d '$dir' ]; then for file in '$dir'/.*; do if [ ! -h '$file' ] && [ -f '$file' ]; then fileperm=$(stat -L -c '%A' '$file') if [ '$(echo '$fileperm' | cut -c6)' != '-' ] || [ '$(echo '$fileperm' | cut -c9)' != '-' ]; then chmod go-w '$file'
fi fi done fi done`

So maybe this should be the default?