### PR TITLE
Adds the option to skip certain files in 6.1.11

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -158,6 +158,8 @@ outputfiles: /root/ #Output dir of some command
 disable_autofs: true
 disable_usb: true
 install_apparmor: true
+# 6.1.11 Ensure no unowned files or directories exist
+strings_to_skip: None #Allows for skipping certain strings in the search. Takes comma separated values such as "/var/lib/docker,/var/lib/kubelet"
 ## 6.2.7 Ensure users' dot files are not group or world accessible
 fix_dot_file_permissions: yes
 include_folders: false # Include folders as well as files

--- a/tasks/section_6_System_Maintenance.yaml
+++ b/tasks/section_6_System_Maintenance.yaml
@@ -143,9 +143,18 @@
 # 6.1.11 Ensure no unowned files or directories exist
 - name: 6.1.11 Ensure no unowned files or directories exist
   block:
-    - name: 6.1.11 Ensure no unowned files or directories exist | Find
-      shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser 2> /dev/null && true || true
-      register: output_6_1_11
+    - name: 6.1.11 Ensure no unowned files or directories exist | No skipped strings
+      block:
+        - name: 6.1.11 Ensure no unowned files or directories exist | Find
+          shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser 2> /dev/null && true || true
+          register: output_6_1_11
+      when: strings_to_skip == None
+    - name: 6.1.11 Ensure no unowned files or directories exist | Skipping specified strings
+      block:
+        - name: 6.1.11 Ensure no unowned files or directories exist | Find
+          shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser 2> /dev/null | grep -v -e  $(echo "{{ strings_to_skip }}" |  sed 's/,/\\|/g') && true || true
+          register: output_6_1_11
+      when: strings_to_skip != None
     - name: 6.1.11 Ensure no unowned files or directories exist | Save output
       copy:
         dest: "{{ outputfiles }}/6.1.11"


### PR DESCRIPTION
In some cases, it is desirable to skip certain files in task 6.1.11, as they may need to not be modified for some programs to keep working. This pull request creates an option to add the path of these files as comma separated strings. When the value of the variable is None, the task runs as normal.