### PR TITLE
Adds option to delete non existing paths from /etc/environment in tas…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -166,3 +166,5 @@ etc_shadow_group: shadow
 ## 6.2.7 Ensure users' dot files are not group or world accessible
 fix_dot_file_permissions: yes
 include_folders: false # Include folders as well as files
+## 6.2.12 Ensure root PATH Integrity
+delete_nonexisting_paths: false # Deletes paths that are neither files nor folders from /etc/environment

--- a/files/6_2_3_delete_nonexisting.sh
+++ b/files/6_2_3_delete_nonexisting.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+if echo $PATH | grep -q "::"; then
+    echo "Empty Directory in PATH (::)"
+fi
+if echo $PATH | grep -q ":$"; then
+    echo "Trailing : in PATH"
+fi
+for x in $(echo $PATH | tr ":" " "); do
+    if [ -d "$x" ]; then
+        ls -ldH "$x" | awk '
+$9 == "." {print "PATH contains current working directory (.)"}
+$3 != "root" {print $9, "is not owned by root"}
+substr($1,6,1) != "-" {print $9, "is group writable"}
+substr($1,9,1) != "-" {print $9, "is world writable"}'
+    else
+        if [ -f "$x" ]; then
+            echo "$x is a file and not a directory"
+        else
+            newpath=$(echo "$PATH" |sed -e "s#\(^\|:\)$(echo "$x" |sed -e 's/[^^]/[&]/g' -e 's/\^/\\^/g')\(:\|/\{0,1\}$\)#\1\2#" -e 's#:\+#:#g' -e 's#^:\|:$##g')
+            sed -i 's%PATH=.*%PATH="'$(echo $newpath)'"%'"" /etc/environment
+    fi
+done

--- a/tasks/section_6_System_Maintenance.yaml
+++ b/tasks/section_6_System_Maintenance.yaml
@@ -469,6 +469,18 @@
 # 6.2.12 Ensure root PATH Integrity
 - name: 6.2.12 Ensure root PATH Integrity
   block:
+    - name: 6.2.12 Ensure root PATH Integrity | run | Delete nonexisting paths
+      block:
+      - name: 6.2.12 Ensure root PATH Integrity | run | Delete nonexisting paths
+        script: 6_2_3_delete_nonexisting.sh
+        register: output_6_2_3
+      when: delete_nonexisting_paths
+    - name: 6.2.12 Ensure root PATH Integrity | run
+      block:
+      - name: 6.2.12 Ensure root PATH Integrity | run
+        script: 6_2_3.sh
+        register: output_6_2_3
+      when: not delete_nonexisting_paths
     - name: 6.2.12 Ensure root PATH Integrity | run
       script: 6_2_3.sh
       register: output_6_2_3


### PR DESCRIPTION
This PR creates an option to delete non existing folders from /etc/environment. This assumes that the $PATH variable for the shell is gotten from /etc/environment. If you consider that this should not only to non existing folders but to any file as well, then I could make that change.