### PR TITLE
Fixes 6.2.5 & 6.2.6 script and tasks naming mix-up

### DIFF
--- a/files/6_2_5.sh
+++ b/files/6_2_5.sh
@@ -1,22 +1,12 @@
 #!/bin/bash
->/tmp/.6.2.5
 grep -E -v '^(halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
     if [ ! -d "$dir" ]; then
-        echo "The home directory ($dir) of user $user does not exist."
+        # echo "No home directory: $dir of user $user"
+        true
     else
-        dirperm=$(ls -ld $dir | cut -f1 -d" ")
-        if [ $(echo $dirperm | cut -c6) != "-" ]; then
-            echo "$dir" >/tmp/.6.2.5
-        fi
-        if [ $(echo $dirperm | cut -c8) != "-" ]; then
-            echo "$dir" >>/tmp/.6.2.5
-        fi
-        if [ $(echo $dirperm | cut -c9) != "-" ]; then
-            echo "$dir" >>/tmp/.6.2.5
-        fi
-        if [ $(echo $dirperm | cut -c10) != "-" ]; then
-            echo "$dir" >>/tmp/.6.2.5
+        owner=$(stat -L -c "%U" "$dir")
+        if [ "$owner" != "$user" ]; then
+            echo ${dir},${user}
         fi
     fi
-    cat /tmp/.6.2.5 | sort -n | uniq
 done

--- a/files/6_2_6.sh
+++ b/files/6_2_6.sh
@@ -1,12 +1,22 @@
 #!/bin/bash
+>/tmp/.6.2.5
 grep -E -v '^(halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
     if [ ! -d "$dir" ]; then
-        # echo "No home directory: $dir of user $user"
-        true
+        echo "The home directory ($dir) of user $user does not exist."
     else
-        owner=$(stat -L -c "%U" "$dir")
-        if [ "$owner" != "$user" ]; then
-            echo ${dir},${user}
+        dirperm=$(ls -ld $dir | cut -f1 -d" ")
+        if [ $(echo $dirperm | cut -c6) != "-" ]; then
+            echo "$dir" >/tmp/.6.2.5
+        fi
+        if [ $(echo $dirperm | cut -c8) != "-" ]; then
+            echo "$dir" >>/tmp/.6.2.5
+        fi
+        if [ $(echo $dirperm | cut -c9) != "-" ]; then
+            echo "$dir" >>/tmp/.6.2.5
+        fi
+        if [ $(echo $dirperm | cut -c10) != "-" ]; then
+            echo "$dir" >>/tmp/.6.2.5
         fi
     fi
+    cat /tmp/.6.2.5 | sort -n | uniq
 done

--- a/tasks/section_6_System_Maintenance.yaml
+++ b/tasks/section_6_System_Maintenance.yaml
@@ -327,21 +327,21 @@
   block:
     - name: 6.2.5 Ensure users own their home directories | list
       script: 6_2_5.sh
-      register: output_6_2_6
+      register: output_6_2_5
     - name: 6.2.5 Ensure users own their home directories | Var
       set_fact:
-        output_6_2_6_list: "{{ output_6_2_6.stdout_lines | list }}"
+        output_6_2_5_list: "{{ output_6_2_5.stdout_lines | list }}"
     - name: 6.2.5 Ensure users own their home directories | save output
       copy:
         dest: "{{ outputfiles }}/6.2.5"
-        content: "{{ output_6_2_6_list }}"
+        content: "{{ output_6_2_5_list }}"
     - name: 6.2.5 Ensure users own their home directories | fix
       file:
         path: "{{ item.split(',')[0] }}"
         group: "{{ item.split(',')[1] }}"
         owner: "{{ item.split(',')[1] }}"
         recurse: yes
-      with_items: "{{ output_6_2_6_list }}"
+      with_items: "{{ output_6_2_5_list }}"
   tags:
     - section6
     - level_1_server
@@ -353,17 +353,17 @@
   block:
     - name: 6.2.6 Ensure users home directories permissions are 750 or more restrictive - list
       script: 6_2_6.sh
-      register: output_6_2_5
+      register: output_6_2_6
     - name: 6.2.6 Ensure users' home directories permissions are 750 or more restrictive - print output
       copy:
         dest: "{{ outputfiles }}/6.2.6"
-        content: "{{ output_6_2_5.stdout_lines }}"
+        content: "{{ output_6_2_6.stdout_lines }}"
     - name: 6.2.6 Ensure users home directories permissions are 750 or more restrictive - fix
       file:
         name: "{{ item }}"
         mode: "g-w,o-rwx"
-      with_items: "{{ output_6_2_5.stdout_lines }}"
-      when: "{{ output_6_2_5.stdout_lines|length > 0 }}"
+      with_items: "{{ output_6_2_6.stdout_lines }}"
+      when: "{{ output_6_2_6.stdout_lines|length > 0 }}"
   tags:
     - section6
     - level_1_server


### PR DESCRIPTION
Commit [ea482867a8cff49db137fd20f69a2a1ac5779446](https://github.com/alivx/CIS-Ubuntu-20.04-Ansible/commit/ea482867a8cff49db137fd20f69a2a1ac5779446) brakes 6.2.5 and 6.2.6.

This PR switches the content of those scripts and fixes the variable names in those tasks.

