### PR TITLE
Fix task 6.2.8 running script 6.2.9 and vice versa

### DIFF
--- a/files/6_2_8.sh
+++ b/files/6_2_8.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
+grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '($7 !="'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
     if [ ! -d "$dir" ]; then
         echo "The home directory ($dir) of user $user does not exist."
     else
-        if [ ! -h "$dir/.forward" -a -f "$dir/.forward" ]; then
-            echo ".forward file $dir/.forward exists"
+        if [ ! -h "$dir/.netrc" -a -f "$dir/.netrc" ]; then
+            echo ".netrc file $dir/.netrc exists"
         fi
     fi
 done

--- a/files/6_2_9.sh
+++ b/files/6_2_9.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '($7 !="'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
+grep -E -v '^(root|halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
     if [ ! -d "$dir" ]; then
         echo "The home directory ($dir) of user $user does not exist."
     else
-        if [ ! -h "$dir/.netrc" -a -f "$dir/.netrc" ]; then
-            echo ".netrc file $dir/.netrc exists"
+        if [ ! -h "$dir/.forward" -a -f "$dir/.forward" ]; then
+            echo ".forward file $dir/.forward exists"
         fi
     fi
 done

--- a/tasks/section_6_System_Maintenance.yaml
+++ b/tasks/section_6_System_Maintenance.yaml
@@ -405,12 +405,12 @@
 - name: 6.2.8 Ensure no users have .netrc files
   block:
     - name: 6.2.8 Ensure no users have .netrc files | list
-      script: 6_2_9.sh
-      register: output_6_2_9
+      script: 6_2_8.sh
+      register: output_6_2_8
     - name: 6.2.8 Ensure no users have .netrc files | save output
       copy:
         dest: "{{ outputfiles }}/6.2.8"
-        content: "{{ output_6_2_9.stdout }}"
+        content: "{{ output_6_2_8.stdout }}"
   tags:
     - section6
     - level_1_server
@@ -422,12 +422,12 @@
 - name: 6.2.9 Ensure no users have .forward files
   block:
     - name: 6.2.9 Ensure no users have .forward files | list
-      script: 6_2_8.sh
-      register: output_6_2_8
+      script: 6_2_9.sh
+      register: output_6_2_9
     - name: 6.2.9 Ensure no users have .forward files  | save output
       copy:
         dest: "{{ outputfiles }}/6.2.9"
-        content: "{{ output_6_2_8.stdout }}"
+        content: "{{ output_6_2_9.stdout }}"
   tags:
     - section6
     - level_1_server


### PR DESCRIPTION
Task `6.2.8` was calling a script called `6.2.9.sh` which implemented the
requirements for task `6.2.8`. `6.2.9` was similarly calling script
`6.2.8.sh`. These tasks called the right script, but were called the
wrong thing. This pull request these typos.

I didn't see a place to update any version numbers in the README as described in the contributing guidelines, but let me know if there is a place I should do that.