### PR TITLE
Adds a parameter to set the mode of /etc/shadow

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -162,6 +162,8 @@ disable_usb: true
 install_apparmor: true
 ## 6.1.6 Ensure permissions on /etc/shadow are configured
 etc_shadow_group: shadow
+## 6.1.7 Ensure permissions on /etc/shadow- are configured
+etc_shadow_mode: 0600 # Must be 0600 or 0640
 # 6.1.11 Ensure no unowned files or directories exist
 unowned_files_strings_to_skip: None #Allows for skipping certain strings in the search. Takes comma separated values such as "/var/lib/docker,/var/lib/kubelet"
 ## 6.2.7 Ensure users' dot files are not group or world accessible

--- a/tasks/section_6_System_Maintenance.yaml
+++ b/tasks/section_6_System_Maintenance.yaml
@@ -86,7 +86,7 @@
     dest: /etc/shadow-
     owner: root
     group: shadow
-    mode: 0600
+    mode: "{{ etc_shadow_mode }}"
   tags:
     - section6
     - level_1_server


### PR DESCRIPTION
Some scanning tools check to see if `/etc/shadow` has mode 0640 instead of 0600. Guidelines indicate the following:
"Access permission is 640 or more restrictive."
So 0640 should be an option as well.