### PR TITLE
Adds task 1.4.1 Ensure permissions on bootloader config are not overridden

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,11 +11,13 @@ disable_udf: yes
 disable_fat: yes
 temp_dir_size: 1G
 disable_squashfs: no #Disabling squashfs will prevent the use of snap
-## 1.5.1 Ensure bootloader password is set (using grub): default is no
+# 1.4.1 Ensure permissions on bootloader config are not overridden
+protect_bootloader_permissions: true
+## 1.4.2 Ensure bootloader password is set (using grub): default is no
 set_bootloader_credentials: no
 ### Update the default bootloader user and password
 bootloader_credentials: { user: "root", password: "b00tl04derPwd" }
-# 1.5.3 Ensure authentication required for single user mode
+# 1.4.3 Ensure authentication required for single user mode
 set_root_password: yes
 root_password: r00tP4ssw0rd
 ## 1.8.1.4 Ensure permissions on /etc/motd are configured: allow for custom motd template (if the file doesn't exist, the

--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -648,12 +648,25 @@
     - level_1_workstation
     - 1.3.2
 
-# 1.4.1 Ensure permissions on bootloader config are not overridden
-# TODO
 
 # 1.5 Secure Boot Settings
 # The recommendations in this section focus on securing the bootloader and settings
 # involved in the boot process directly.
+
+# 1.4.1 Ensure permissions on bootloader config are not overridden
+- name: 1.4.1 Ensure permissions on bootloader config are not overridden 
+  block:
+    - name: 1.4.1 Ensure permissions on bootloader config are not overridden - step 1 - update chmod 444 to chmod 400 in /usr/sbin/grubmkconfig
+      shell: sed -ri 's/chmod\s+[0-7][0-7][0-7]\s+\$\{grub_cfg\}\.new/chmod 400 ${grub_cfg}.new/' /usr/sbin/grub-mkconfig
+    - name: 1.4.1 Ensure permissions on bootloader config are not overridden - step 2 -  check on password not being set to before running chmod command
+      shell:  sed -ri 's/ && ! grep "\^password" \$\{grub_cfg\}.new >\/dev\/null//' /usr/sbin/grub-mkconfig
+  when: protect_bootloader_permissions
+  tags:
+    - section1
+    - level_1_server
+    - level_1_workstation
+    - 1.4.1
+
 # 1.4.2 Ensure bootloader password is set
 # Setting the boot loader password will require that anyone rebooting the system must enter
 # a password before being able to set command line boot parameters

--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -658,7 +658,7 @@
   block:
     - name: 1.4.1 Ensure permissions on bootloader config are not overridden - step 1 - update chmod 444 to chmod 400 in /usr/sbin/grubmkconfig
       shell: sed -ri 's/chmod\s+[0-7][0-7][0-7]\s+\$\{grub_cfg\}\.new/chmod 400 ${grub_cfg}.new/' /usr/sbin/grub-mkconfig
-    - name: 1.4.1 Ensure permissions on bootloader config are not overridden - step 2 -  check on password not being set to before running chmod command
+    - name: 1.4.1 Ensure permissions on bootloader config are not overridden - step 2 -  check on password not being set before running chmod command
       shell:  sed -ri 's/ && ! grep "\^password" \$\{grub_cfg\}.new >\/dev\/null//' /usr/sbin/grub-mkconfig
   when: protect_bootloader_permissions
   tags:


### PR DESCRIPTION
This PR adds task 1.4.1 in accordance to the CIS Ubuntu Linux 20.04 LTS Benchmark.
