### PR TITLE
5.5.5 Adds readonly to TMOUT variable as per CIS recommendations

### DIFF
--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -758,22 +758,22 @@
         state: present
         dest: /etc/bash.bashrc
         create: true
-        regexp: "^TMOUT="
-        line: "TMOUT={{ shell_timeout_sec }} ; export TMOUT"
+        regexp: "^TMOUT=|^readonly TMOUT="
+        line: "unset test 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
     - name: 5.5.5 Ensure default user shell timeout is 900 seconds or less | /etc/profile
       lineinfile:
         state: present
         dest: /etc/profile
         create: true
-        regexp: "^TMOUT="
-        line: "TMOUT={{ shell_timeout_sec }} ; export TMOUT"
+        regexp: "^TMOUT=|^readonly TMOUT="
+        line: "unset test 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
     - name: 5.5.5 Ensure default user shell timeout is 900 seconds or less | /etc/profile.d/timeout.sh
       lineinfile:
         state: present
         dest: /etc/profile.d/tmout.sh
         create: true
-        regexp: "^TMOUT="
-        line: "TMOUT={{ shell_timeout_sec }} ; export TMOUT"
+        regexp: "^TMOUT=|^readonly TMOUT="
+        line: "unset test 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
   tags:
     - section5
     - level_1_server

--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -767,22 +767,22 @@
         state: present
         dest: /etc/bash.bashrc
         create: true
-        regexp: "^TMOUT=|^readonly TMOUT="
-        line: "unset test 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
+        regexp: "^TMOUT=|^readonly TMOUT=|^unset TMOUT"
+        line: "unset TMOUT 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
     - name: 5.5.5 Ensure default user shell timeout is 900 seconds or less | /etc/profile
       lineinfile:
         state: present
         dest: /etc/profile
         create: true
-        regexp: "^TMOUT=|^readonly TMOUT="
-        line: "unset test 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
+        regexp: "^TMOUT=|^readonly TMOUT=|^unset TMOUT"
+        line: "unset TMOUT 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
     - name: 5.5.5 Ensure default user shell timeout is 900 seconds or less | /etc/profile.d/timeout.sh
       lineinfile:
         state: present
         dest: /etc/profile.d/tmout.sh
         create: true
-        regexp: "^TMOUT=|^readonly TMOUT="
-        line: "unset test 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
+        regexp: "^TMOUT=|^readonly TMOUT=|^unset TMOUT"
+        line: "unset TMOUT 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
   tags:
     - section5
     - level_1_server


### PR DESCRIPTION
CIS recommends that `readonly` be used when setting the TMOUT variable. The modification made to task 5.5.5 allows for this.
The part `unset TMOUT 2> /dev/null &&` makes sure not to try to override the TMOUT variable if it is already set as readonly. This avoids the following message when logging in to the terminal:
`-bash: TMOUT: readonly variable`