### PR TITLE
6.2.6 Adds an extra filter in case of using a different nologin

### DIFF
--- a/files/6_2_6.sh
+++ b/files/6_2_6.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 >/tmp/.6.2.5
-grep -E -v '^(halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
+grep -E -v '^(halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false" && $7 !~ "/nologin" ) { print $1 " " $6 }' | while read user dir; do
     if [ ! -d "$dir" ]; then
         echo "The home directory ($dir) of user $user does not exist."
     else

--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -758,22 +758,22 @@
         state: present
         dest: /etc/bash.bashrc
         create: true
-        regexp: "^TMOUT="
-        line: "TMOUT={{ shell_timeout_sec }} ; export TMOUT"
+        regexp: "^TMOUT=|^readonly TMOUT="
+        line: "unset test 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
     - name: 5.5.5 Ensure default user shell timeout is 900 seconds or less | /etc/profile
       lineinfile:
         state: present
         dest: /etc/profile
         create: true
-        regexp: "^TMOUT="
-        line: "TMOUT={{ shell_timeout_sec }} ; export TMOUT"
+        regexp: "^TMOUT=|^readonly TMOUT="
+        line: "unset test 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
     - name: 5.5.5 Ensure default user shell timeout is 900 seconds or less | /etc/profile.d/timeout.sh
       lineinfile:
         state: present
         dest: /etc/profile.d/tmout.sh
         create: true
-        regexp: "^TMOUT="
-        line: "TMOUT={{ shell_timeout_sec }} ; export TMOUT"
+        regexp: "^TMOUT=|^readonly TMOUT="
+        line: "unset test 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
   tags:
     - section5
     - level_1_server

--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -767,22 +767,22 @@
         state: present
         dest: /etc/bash.bashrc
         create: true
-        regexp: "^TMOUT=|^readonly TMOUT="
-        line: "unset test 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
+        regexp: "^TMOUT=|^readonly TMOUT=|^unset TMOUT"
+        line: "unset TMOUT 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
     - name: 5.5.5 Ensure default user shell timeout is 900 seconds or less | /etc/profile
       lineinfile:
         state: present
         dest: /etc/profile
         create: true
-        regexp: "^TMOUT=|^readonly TMOUT="
-        line: "unset test 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
+        regexp: "^TMOUT=|^readonly TMOUT=|^unset TMOUT"
+        line: "unset TMOUT 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
     - name: 5.5.5 Ensure default user shell timeout is 900 seconds or less | /etc/profile.d/timeout.sh
       lineinfile:
         state: present
         dest: /etc/profile.d/tmout.sh
         create: true
-        regexp: "^TMOUT=|^readonly TMOUT="
-        line: "unset test 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
+        regexp: "^TMOUT=|^readonly TMOUT=|^unset TMOUT"
+        line: "unset TMOUT 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
   tags:
     - section5
     - level_1_server


### PR DESCRIPTION
Currently task 6.2.6 filters users with 
`$7 != "'"$(which nologin)"'" && $7 != "/bin/false"`
where $7 is usually one of these values
`/usr/sbin/nologin
/bin/false
/bin/bash`
This check fails if $7 takes the following value (for example)
`/sbin/nologin`
if `which nologin` cannot find this path, this user does not get filtered and causes errors in the script.

I've added an additional check for `"/nologin"` so that all users are correctly filtered.