### PR TITLE
Adds better regex matching for task 5.3.10 and changes line for better compatibility with vulnerability scanners

### DIFF
--- a/files/6_2_6.sh
+++ b/files/6_2_6.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 >/tmp/.6.2.5
-grep -E -v '^(halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false") { print $1 " " $6 }' | while read user dir; do
+grep -E -v '^(halt|sync|shutdown)' /etc/passwd | awk -F: '($7 != "'"$(which nologin)"'" && $7 != "/bin/false" && $7 !~ "/nologin" ) { print $1 " " $6 }' | while read user dir; do
     if [ ! -d "$dir" ]; then
         echo "The home directory ($dir) of user $user does not exist."
     else

--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -758,22 +758,22 @@
         state: present
         dest: /etc/bash.bashrc
         create: true
-        regexp: "^TMOUT="
-        line: "TMOUT={{ shell_timeout_sec }} ; export TMOUT"
+        regexp: "^TMOUT=|^readonly TMOUT="
+        line: "unset test 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
     - name: 5.5.5 Ensure default user shell timeout is 900 seconds or less | /etc/profile
       lineinfile:
         state: present
         dest: /etc/profile
         create: true
-        regexp: "^TMOUT="
-        line: "TMOUT={{ shell_timeout_sec }} ; export TMOUT"
+        regexp: "^TMOUT=|^readonly TMOUT="
+        line: "unset test 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
     - name: 5.5.5 Ensure default user shell timeout is 900 seconds or less | /etc/profile.d/timeout.sh
       lineinfile:
         state: present
         dest: /etc/profile.d/tmout.sh
         create: true
-        regexp: "^TMOUT="
-        line: "TMOUT={{ shell_timeout_sec }} ; export TMOUT"
+        regexp: "^TMOUT=|^readonly TMOUT="
+        line: "unset test 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
   tags:
     - section5
     - level_1_server

--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -767,22 +767,22 @@
         state: present
         dest: /etc/bash.bashrc
         create: true
-        regexp: "^TMOUT=|^readonly TMOUT="
-        line: "unset test 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
+        regexp: "^TMOUT=|^readonly TMOUT=|^unset TMOUT"
+        line: "unset TMOUT 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
     - name: 5.5.5 Ensure default user shell timeout is 900 seconds or less | /etc/profile
       lineinfile:
         state: present
         dest: /etc/profile
         create: true
-        regexp: "^TMOUT=|^readonly TMOUT="
-        line: "unset test 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
+        regexp: "^TMOUT=|^readonly TMOUT=|^unset TMOUT"
+        line: "unset TMOUT 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
     - name: 5.5.5 Ensure default user shell timeout is 900 seconds or less | /etc/profile.d/timeout.sh
       lineinfile:
         state: present
         dest: /etc/profile.d/tmout.sh
         create: true
-        regexp: "^TMOUT=|^readonly TMOUT="
-        line: "unset test 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
+        regexp: "^TMOUT=|^readonly TMOUT=|^unset TMOUT"
+        line: "unset TMOUT 2> /dev/null && readonly TMOUT={{ shell_timeout_sec }} ; export TMOUT"
   tags:
     - section5
     - level_1_server

--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -330,13 +330,13 @@
     - name: "5.3.10 Ensure SSH root login is disabled: remove root login for all existing IPs"
       replace:
         dest: /etc/ssh/sshd_config
-        regexp: "^Match Address.*\n.*PermitRootLogin.*$"
+        regexp: "^[Mm]atch [Aa]ddress.*\n.*PermitRootLogin.*$"
     - name: "5.3.10 Ensure SSH root login is disabled: allow ssh root login from '{{ ssh_root_login_ips }}'"
       lineinfile:
         state: present
         dest: /etc/ssh/sshd_config
-        regexp: "^Match Address.*\n*PermitRootLogin.*"
-        line: "Match Address {{ ssh_root_login_ips }}\n PermitRootLogin yes"
+        regexp: "^[Mm]atch [Aa]ddress.*\n*PermitRootLogin.*"
+        line: "Match address {{ ssh_root_login_ips }}\n PermitRootLogin yes"
       when: (ssh_root_login_ips != "None") and (ssh_root_login_ips|length > 0)
   tags:
   - section5


### PR DESCRIPTION
Some automated vulnerability scanners such as Nessus match the `Match address` line with a lowercase 'a'. I've implemented a change to reflect this. I've also added matching with lower case 'a' and 'm' in the regex used.