### PR TITLE
Fixes task 6.2.7

### DIFF
--- a/tasks/section_6_System_Maintenance.yaml
+++ b/tasks/section_6_System_Maintenance.yaml
@@ -373,11 +373,11 @@
 # 6.2.7 Ensure users' dot files are not group or world writable
 - name: 6.2.7 Ensure users dot files are not group or world writable
   block:
-    - name: 6.2.7 Ensure users dot files are not group or world writable | list
+    - name: 6.2.7 Ensure users' dot files are not group or world writable | list
       script: 6_2_7.sh
       register: output_6_2_7_files
       when: not fix_dot_include_folders
-    - name: 6.2.7 Ensure users dot files and folders are not group or world writable | list
+    - name: 6.2.7 Ensure users' dot files and folders are not group or world writable | list
       script: 6_2_7_include_folders.sh
       register: output_6_2_7_folders
       when: fix_dot_include_folders
@@ -386,7 +386,7 @@
         dest: "{{ outputfiles }}/6.2.7"
         content: "{{ output_6_2_7_files.stdout }}"
       when: not fix_dot_include_folders
-    - name: 6.2.7 Ensure users' dot files are not group or world writable | save output
+    - name: 6.2.7 Ensure users' dot files and folders are not group or world writable | save output
       copy:
         dest: "{{ outputfiles }}/6.2.7"
         content: "{{ output_6_2_7_folders.stdout }}"
@@ -396,10 +396,21 @@
       file:
         path: "{{ item.split()[-1] }}"
         mode: g-w,o-w
-      with_items: "{{ output_6_2_7.stdout_lines }}"
+      with_items: "{{ output_6_2_7_files.stdout_lines }}"
       when:
         - fix_dot_file_permissions
-        - output_6_2_7.stdout
+        - output_6_2_7_files.stdout
+        - not fix_dot_include_folders
+    - name: 6.2.7 Ensure users' dot files and folders are not group or world writable | correct file permissions
+      # files with go+w will be touched twice, as they figure twice in the filter result
+      file:
+        path: "{{ item.split()[-1] }}"
+        mode: g-w,o-w
+      with_items: "{{ output_6_2_7_folders.stdout_lines }}"
+      when:
+        - fix_dot_file_permissions
+        - output_6_2_7_folders.stdout
+        - fix_dot_include_folders
   tags:
     - section6
     - level_1_server


### PR DESCRIPTION
Fixes the name an error with the following output
`fatal: [node-1]: FAILED! => {"msg": "'output_6_2_7' is undefined"}`
`output_6_2_7` had been renamed to `output_6_2_7_folders` and `output_6_2_7_files` but the "correct file permissions" task had not been changed