### PR TITLE
chore: Extends 3.3.4 to include files used by ufw

### DIFF
--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -247,6 +247,8 @@
         path: /etc/ufw/sysctl.conf
         regexp: '^(net.ipv4.conf.*.log_martians=1)$'
         replace: '# \g<1>'
+      # Shouldn't fail if target file doesn't exist
+      ignore_errors: yes
     - name: 3.3.4 Ensure suspicious packets are logged | restart ufw after changes in /etc/ufw/sysctl.conf
       service:
         name: ufw

--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -242,6 +242,17 @@
         sysctl -w net.ipv4.conf.all.log_martians=1
         sysctl -w net.ipv4.conf.default.log_martians=1
         sysctl -w net.ipv4.route.flush=1
+    - name: 3.3.4 Ensure suspicious packets are logged | remove flags from /etc/ufw/sysctl.conf
+      replace:
+        path: /etc/ufw/sysctl.conf
+        regexp: '^(net.ipv4.conf.*.log_martians=1)$'
+        replace: '# \g<1>'
+    - name: 3.3.4 Ensure suspicious packets are logged | restart ufw after changes in /etc/ufw/sysctl.conf
+      service:
+        name: ufw
+        state: restarted
+      when: UFWEnable
+
   tags:
     - section3
     - level_1_server


### PR DESCRIPTION
We have seen that in some cases, the "martians" settings are being taken from the /etc/ufw/sysctl file, overriding the default files. 

This PR comments the relevant lines in /etc/ufw/sysctl.