### PR TITLE
bugfix(3.3.4): Corrects regexp to find martians in /etc/ufw/sysctl.conf

### DIFF
--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -245,7 +245,7 @@
     - name: 3.3.4 Ensure suspicious packets are logged | remove flags from /etc/ufw/sysctl.conf
       replace:
         path: /etc/ufw/sysctl.conf
-        regexp: '^(net.ipv4.conf.*.log_martians=1)$'
+        regexp: '^(net/ipv4/conf/.*/log_martians=.*)$'
         replace: '# \g<1>'
       # Shouldn't fail if target file doesn't exist
       ignore_errors: yes


### PR DESCRIPTION
bugfix(3.3.4): Corrects regexp to find martians in /etc/ufw/sysctl.conf

Instead of looking for `net/ipv4/conf/.*/log_martians=.*`, the regexp was looking for `net.ipv4.conf.*.log_martians=1`.
We now also always comment the lines, irrespective of whether the active value was 0 or 1. 