### PR TITLE
bugfix: Adds call to sshd restart handler to last task that modifies /etc/ssh/sshd_config [CLTE2101-443]

### DIFF
--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -503,11 +503,12 @@
     dest: /etc/ssh/sshd_config
     regexp: "^MaxSessions"
     line: "MaxSessions {{ ssh_max_sessions }}"
+  notify: sshd restart
   tags:
     - section5
     - level_1_server
     - level_1_workstation
-    - 5.3.21
+    - 5.3.22
 # 5.4 Configure PAM
 # 5.4.1 Ensure password creation requirements are configured
 # Strong passwords protect systems from being hacked through brute force methods.


### PR DESCRIPTION
After changes to `/etc/ssh/sshd_config`, no tasks restarts the ssh service. This PR adds a call to the already existing but unused handler that does this.

Also fixes an incorrect tag in the same task.