### PR TITLE
bugfix: Ensures ssh daemon is restarted at end of ssh changes

### DIFF
--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -503,12 +503,22 @@
     dest: /etc/ssh/sshd_config
     regexp: "^MaxSessions"
     line: "MaxSessions {{ ssh_max_sessions }}"
-  notify: sshd restart
   tags:
     - section5
     - level_1_server
     - level_1_workstation
     - 5.3.22
+# 5.3.X Restart sshd service so that any previous changes take effect
+- name: "5.3.X Restart sshd"
+  service:
+    name: sshd
+    state: restarted
+  tags:
+    - section5
+    - level_1_server
+    - level_1_workstation
+    - 5.3.X
+
 # 5.4 Configure PAM
 # 5.4.1 Ensure password creation requirements are configured
 # Strong passwords protect systems from being hacked through brute force methods.


### PR DESCRIPTION
The previous PR (using handlers) didn't really restart the daemon, so I added a new task at the end of the ssh tasks to do it "manually". I tested it and it does restart the daemon.