### PR TITLE
bugfix: Ensures all files to be fixed are found [6.1.10, 6.1.11, 6.1.12, 6.1.13, 6.1.14]

### DIFF
--- a/tasks/section_6_System_Maintenance.yaml
+++ b/tasks/section_6_System_Maintenance.yaml
@@ -123,7 +123,7 @@
 - name: 6.1.10 Ensure no world writable files exist
   block:
     - name: 6.1.10 Ensure no world writable files exist | find files
-      shell: df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type f -perm -0002 2> /dev/null && true || true
+      shell: df --local -P | awk '{if (NR!=1) print $6}' | sudo xargs -I '{}' find '{}' -xdev -type f -perm -0002 2> /dev/null && true || true
       register: output_6_1_10
     - name: 6.1.10 Ensure no world writable files exist | save output
       copy:
@@ -146,13 +146,13 @@
     - name: 6.1.11 Ensure no unowned files or directories exist | No skipped strings
       block:
         - name: 6.1.11 Ensure no unowned files or directories exist | Find
-          shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser 2> /dev/null && true || true
+          shell: df --local -P | awk {'if (NR!=1) print $6'} | sudo xargs -I '{}' find '{}' -xdev -nouser 2> /dev/null && true || true
           register: output_6_1_11
       when: unowned_files_strings_to_skip == None
     - name: 6.1.11 Ensure no unowned files or directories exist | Skipping specified strings
       block:
         - name: 6.1.11 Ensure no unowned files or directories exist | Find
-          shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser 2> /dev/null | grep -v -e  $(echo "{{ unowned_files_strings_to_skip }}" |  sed 's/,/\\|/g') && true || true
+          shell: df --local -P | awk {'if (NR!=1) print $6'} | sudo xargs -I '{}' find '{}' -xdev -nouser 2> /dev/null | grep -v -e  $(echo "{{ unowned_files_strings_to_skip }}" |  sed 's/,/\\|/g') && true || true
           register: output_6_1_11
       when: unowned_files_strings_to_skip != None
     - name: 6.1.11 Ensure no unowned files or directories exist | Save output
@@ -174,7 +174,7 @@
 - name: 6.1.12 Ensure no ungrouped files or directories exist
   block:
     - name: 6.1.12 Ensure no ungrouped files or directories exist | Find
-      shell: df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -nogroup 2> /dev/null && true || true
+      shell: df --local -P | awk '{if (NR!=1) print $6}' | sudo xargs -I '{}' find '{}' -xdev -nogroup 2> /dev/null && true || true
       register: output_6_1_12
     - name: 6.1.12 Ensure no ungrouped files or directories exist | Save output
       copy:
@@ -195,7 +195,7 @@
 - name: 6.1.13 Audit SUID executables
   block:
     - name: 6.1.13 Audit SUID executables | find
-      shell: df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type f -perm -4000 2> /dev/null && true || true
+      shell: df --local -P | awk '{if (NR!=1) print $6}' | sudo xargs -I '{}' find '{}' -xdev -type f -perm -4000 2> /dev/null && true || true
       register: output_6_1_13
     - name: 6.1.13 Audit SUID executables | save output
       copy:
@@ -216,7 +216,7 @@
 - name: 6.1.14 Audit SGID executables
   block:
     - name: 6.1.14 Audit SGID executables | find
-      shell: df --local -P | awk '{if (NR!=1) print $6}' | xargs -I '{}' find '{}' -xdev -type f -perm -2000 2> /dev/null && true || true
+      shell: df --local -P | awk '{if (NR!=1) print $6}' | sudo xargs -I '{}' find '{}' -xdev -type f -perm -2000 2> /dev/null && true || true
       register: output_6_1_14
     - name: 6.1.14 Audit SGID executables | save output
       copy:


### PR DESCRIPTION
In tasks 6.1.10, 6.1.11, 6.1.12, 6.1.13, 6.1.14, `xargs` is used to change file permissions after finding files with `df` commands. The issue is that with `become: yes`, only the first part of the command is executed with `sudo` but not the second part, so that the `find` sentence of the second part doesn't have access to the files found with the `sudo df` command

`df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser 2> /dev/null && true || true` -> finds nothing
 `df --local -P | awk {'if (NR!=1) print $6'} | sudo xargs -I '{}' find '{}' -xdev -nouser` -> finds files
 
![image](https://user-images.githubusercontent.com/45768550/179093179-984a3555-0512-48ea-beb6-fee6dd192435.png)
![image](https://user-images.githubusercontent.com/45768550/179093228-67eef922-214a-4f47-946b-8f2bfada0cae.png)

This fix adds `sudo` to the second part of the relevant commands.