### PR TITLE
bugfix: Corrects task 3.1.1 - Disable IPv6

### DIFF
--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -18,9 +18,10 @@
         state: present
         reload: true
       with_items:
-        - { name: net.ipv4.conf.all.send_redirects, value: 0 }
-        - { name: net.ipv4.conf.default.send_redirects, value: 0 }
-  when: IPv6_is_enabled
+        - { name: net.ipv6.conf.all.disable_ipv6, value: 1 }
+        - { name: net.ipv6.conf.default.disable_ipv6, value: 1 }
+        - { name: net.ipv6.route.flush=1, value: 1 }
+  when: not IPv6_is_enabled
   tags:
     - section3
     - level_2_server

--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -20,8 +20,8 @@
       with_items:
         - { name: net.ipv6.conf.all.disable_ipv6, value: 1 }
         - { name: net.ipv6.conf.default.disable_ipv6, value: 1 }
-        - { name: net.ipv6.route.flush=1, value: 1 }
-  when: not IPv6_is_enabled
+        - { name: net.ipv6.route.flush, value: 1 }
+  when: IPv6_is_enabled is defined and not IPv6_is_enabled
   tags:
     - section3
     - level_2_server


### PR DESCRIPTION
* `when: IPv6_is_enabled` clause variable should be negated for correct execution of disabling IPv6.

* Corrects sysctl clauses as per CIS:
![image](https://user-images.githubusercontent.com/45768550/181123301-6761c192-ec44-41c1-826a-79551823cbe4.png)
