### PR TITLE
bugfix: Corrects task 1.1.1.6's tag

### DIFF
--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -163,7 +163,7 @@
     - section1
     - level_1_server
     - level_1_workstation
-    - 1.1.1.5
+    - 1.1.1.6
     - filesystems
     - squashfs
     - modprobe


### PR DESCRIPTION
Wrong tag 1.1.1.5 in task's tags:

```
- name: 1.1.1.6 Ensure mounting of squashfs filesystems is disabled
  block:
    - name: 1.1.1.6 Ensure mounting of squashfs filesystems is disabled

   ...  
  tags:
    - section1
    - level_1_server
    - level_1_workstation
    - 1.1.1.5 <<<-------------
    - filesystems
    - squashfs
    - modprobe