### PR TITLE
feature: Extends task 4.4 to take files in logrotate.d in consideration.

### DIFF
--- a/tasks/section_4_Logging_and_Auditing.yaml
+++ b/tasks/section_4_Logging_and_Auditing.yaml
@@ -491,13 +491,33 @@
 # 4.4 Ensure logrotate assigns appropriate permissions
 # It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected.
 - name: 4.4 Ensure logrotate assigns appropriate permissions
-  lineinfile:
-    dest: /etc/logrotate.conf
-    regexp: "^create\\s*(\\S*)\\s*(\\S*)\\s*(\\S*)"
-    line: create 0640 \g<2> \g<3>
-    backrefs: true
-  notify:
-    - journald restart
+  block:
+    - name: 4.4 Ensure logrotate assigns appropriate permissions - /etc/logrotate.conf
+      lineinfile:
+        path: /etc/logrotate.conf
+        regexp: "^(\\*)screate\\s*(\\S*)\\s*(\\S*)\\s*(\\S*)"
+        line: \g<1> create 0640 \g<3> \g<4>
+        backrefs: true
+      notify:
+        - journald restart
+    - name: 4.4 Ensure logrotate assigns appropriate permissions - Find files in /etc/logrotate.d/*
+      find:
+        file_type: file
+        paths: "/etc/logrotate.d/"
+      register: configFiles
+    - name: Debug
+      debug:
+          msg: "{{ item.path }}"
+      with_items: " {{ configFiles.files }}"
+    - name: 4.4 Ensure logrotate assigns appropriate permissions - Change files in /etc/logrotate.d/*
+      lineinfile:
+        path: "{{ item.path }}"
+        regexp: "^(\\s*)create\\s*(\\S*)\\s*(\\S*)\\s*(\\S*)"
+        line: \g<1> create 0640 \g<3> \g<4>
+        backrefs: true
+      with_items: " {{ configFiles.files }}"
+      notify:
+        - journald restart
   tags:
     - section4
     - level_1_server


### PR DESCRIPTION
_4.4 Ensure logrotate assigns appropriate permissions_ only considers /etc/logrotate.conf and not the configuration files in /etc/logrotate.d/. This PR adds this and also slightly changes the original regexp to take whitespace into account.

Before:
```
ubuntu@hardening:/etc/logrotate.d$ grep create *
alternatives:create 0640 root root
btmp:    create 0660 root utmp
dpkg:create 0640 root root
wtmp:    create 0664 root utmp
```

After:
```
ubuntu@hardening:/etc/logrotate.d$ grep create *
alternatives: create 0640 root root
btmp:     create 0640 root utmp
dpkg: create 0640 root root
wtmp:     create 0640 root utmp
