### PR TITLE
chore: Moves "Ensure sudo is installed" to section 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,46 +191,45 @@ _________________
   - ~~1.2.1 Ensure package manager repositories are configured (Manual)~~
   - ~~1.2.2 Ensure GPG keys are configured (Manual)~~
 
-**1.3 Configure sudo**
+**1.3 Filesystem Integrity Checking**
 
-  - 1.3.1 Ensure sudo is installed (Automated)
-  - 1.3.2 Ensure sudo commands use pty (Automated)
-  - 1.3.3 Ensure sudo log file exists (Automated)
+  - 1.3.1 Ensure AIDE is installed (Automated)
+  - 1.3.2 Ensure filesystem integrity is regularly checked (Automated)
 
-**1.4 Filesystem Integrity Checking**
+**1.4 Secure Boot Settings**
 
-  - 1.4.1 Ensure AIDE is installed (Automated)
-  - 1.4.2 Ensure filesystem integrity is regularly checked (Automated)
+  - 1.4.1 Ensure bootloader password is set (Automated)
+  - 1.4.2 Ensure permissions on bootloader config are configured (Automated)
+  - 1.4.3 Ensure authentication required for single user mode (Automated)
 
-**1.5 Secure Boot Settings**
+**1.5 Additional Process Hardening**
+  - 1.5.1 Ensure XD/NX support is enabled (Automated)
+  - 1.5.2 Ensure address space layout randomization (ASLR) is enabled (Automated)
+  - 1.5.3 Ensure prelink is disabled (Automated)
+  - 1.5.4 Ensure core dumps are restricted (Automated)
 
-  - 1.5.1 Ensure bootloader password is set (Automated)
-  - 1.5.2 Ensure permissions on bootloader config are configured - (Automated)
-  - 1.5.3 Ensure authentication required for single user mode (Automated)
+**1.6 Mandatory Access Control**
+  - 1.6.1 Configure AppArmor
+  - 1.6.1.1 Ensure AppArmor is installed (Automated)
+  - 1.6.1.2 Ensure AppArmor is enabled in the bootloader configuration (Automated)
+  - 1.6.1.3 Ensure all AppArmor Profiles are in enforce or complain mode (Automated)
+  - 1.6.1.4 Ensure all AppArmor Profiles are enforcing (Automated)
 
-**1.6 Additional Process Hardening**
-  - 1.6.1 Ensure XD/NX support is enabled (Automated)
-  - 1.6.2 Ensure address space layout randomization (ASLR) is enabled - (Automated)
-  - 1.6.3 Ensure prelink is disabled (Automated)
-  - 1.6.4 Ensure core dumps are restricted (Automated)
+**1.7 Warning Banners**
+  - 1.7.1.1 Ensure message of the day is configured properly (Automated)
+  - 1.7.1.2 Ensure local login warning banner is configured properly (Automated) 
+  - 1.7.1.3 Ensure remote login warning banner is configured properly (Automated)
+  - 1.7.1.4 Ensure permissions on /etc/motd are configured (Automated)
+  - 1.7.1.5 Ensure permissions on /etc/issue are configured (Automated)
+  - 1.7.1.6 Ensure permissions on /etc/issue.net are configured (Automated)
 
-**1.7 Mandatory Access Control**
-  - 1.7.1 Configure AppArmor
-  - 1.7.1.1 Ensure AppArmor is installed (Automated)
-  - 1.7.1.2 Ensure AppArmor is enabled in the bootloader configuration - (Automated)
-  - 1.7.1.3 Ensure all AppArmor Profiles are in enforce or complain mode - (Automated)
-  - 1.7.1.4 Ensure all AppArmor Profiles are enforcing (Automated)
+**1.8 GNOME Display Manager**
+  - 1.8.1 Ensure GNOME Display Manager is removed (Manual)
+  - 1.8.2 Ensure GDM login banner is configured (Manual)
+  - 1.8.3 Ensure disable-user-list is enabled (Manual)
+  - 1.8.4 Ensure XDCMP is not enabled (Manual)
 
-**1.8 Warning Banners**
-  - 1.8.1 Command Line Warning Banners
-  - 1.8.1.1 Ensure message of the day is configured properly (Automated)
-  - 1.8.1.2 Ensure local login warning banner is configured properly - (Automated) 115
-  - 1.8.1.3 Ensure remote login warning banner is configured properly - (Automated)
-  - 1.8.1.4 Ensure permissions on /etc/motd are configured (Automated)
-  - 1.8.1.5 Ensure permissions on /etc/issue are configured (Automated)
-  - 1.8.1.6 Ensure permissions on /etc/issue.net are configured - (Automated)
-  - 1.9 Ensure updates, patches, and additional security software are - installed (Manual)
-  - 1.10 Ensure GDM is removed or login is configured (Automated)
+**1.9 Ensure updates, patches, and additional security software are installed (Automated)**
 
 **2 Services**
   - 2.1 inetd Services

--- a/index.html
+++ b/index.html
@@ -191,46 +191,45 @@ _________________
   - ~~1.2.1 Ensure package manager repositories are configured (Manual)~~
   - ~~1.2.2 Ensure GPG keys are configured (Manual)~~
 
-**1.3 Configure sudo**
+**1.3 Filesystem Integrity Checking**
 
-  - 1.3.1 Ensure sudo is installed (Automated)
-  - 1.3.2 Ensure sudo commands use pty (Automated)
-  - 1.3.3 Ensure sudo log file exists (Automated)
+  - 1.3.1 Ensure AIDE is installed (Automated)
+  - 1.3.2 Ensure filesystem integrity is regularly checked (Automated)
 
-**1.4 Filesystem Integrity Checking**
+** 1.4 Secure Boot Settings
+  - 1.4.1 Ensure permissions on bootloader config are not overridden (Automated)
+  - 1.4.2 Ensure bootloader password is set (Automated)
+  - 1.4.3 Ensure permissions on bootloader config are configured (Automated)
+  - 1.4.4 Ensure authentication required for single user mode (Automated)
 
-  - 1.4.1 Ensure AIDE is installed (Automated)
-  - 1.4.2 Ensure filesystem integrity is regularly checked (Automated)
+**1.5 Additional Process Hardening**
+  - 1.5.1 Ensure XD/NX support is enabled (Automated)
+  - 1.5.2 Ensure address space layout randomization (ASLR) is enabled (Automated)
+  - 1.5.3 Ensure prelink is disabled (Automated)
+  - 1.5.4 Ensure core dumps are restricted (Automated)
 
-**1.5 Secure Boot Settings**
+**1.6 Mandatory Access Control**
+  - 1.6.1 Configure AppArmor
+  - 1.6.1.1 Ensure AppArmor is installed (Automated)
+  - 1.6.1.2 Ensure AppArmor is enabled in the bootloader configuration (Automated)
+  - 1.6.1.3 Ensure all AppArmor Profiles are in enforce or complain mode (Automated)
+  - 1.6.1.4 Ensure all AppArmor Profiles are enforcing (Automated)
 
-  - 1.5.1 Ensure bootloader password is set (Automated)
-  - 1.5.2 Ensure permissions on bootloader config are configured - (Automated)
-  - 1.5.3 Ensure authentication required for single user mode (Automated)
+**1.7 Warning Banners**
+  - 1.7.1 Ensure message of the day is configured properly
+  - 1.7.2 Ensure local login warning banner is configured properly
+  - 1.7.3 Ensure remote login warning banner is configured properly
+  - 1.7.4 Ensure permissions on /etc/motd are configured
+  - 1.7.5 Ensure permissions on /etc/issue are configured
+  - 1.7.6 Ensure permissions on /etc/issue.net are configured
 
-**1.6 Additional Process Hardening**
-  - 1.6.1 Ensure XD/NX support is enabled (Automated)
-  - 1.6.2 Ensure address space layout randomization (ASLR) is enabled - (Automated)
-  - 1.6.3 Ensure prelink is disabled (Automated)
-  - 1.6.4 Ensure core dumps are restricted (Automated)
+**1.8 GNOME Display Manager**
+  - 1.8.1 Ensure GNOME Display Manager is removed (Manual)
+  - 1.8.2 Ensure GDM login banner is configured (Manual)
+  - 1.8.3 Ensure disable-user-list is enabled (Manual)
+  - 1.8.4 Ensure XDCMP is not enabled (Manual)
 
-**1.7 Mandatory Access Control**
-  - 1.7.1 Configure AppArmor
-  - 1.7.1.1 Ensure AppArmor is installed (Automated)
-  - 1.7.1.2 Ensure AppArmor is enabled in the bootloader configuration - (Automated)
-  - 1.7.1.3 Ensure all AppArmor Profiles are in enforce or complain mode - (Automated)
-  - 1.7.1.4 Ensure all AppArmor Profiles are enforcing (Automated)
-
-**1.8 Warning Banners**
-  - 1.8.1 Command Line Warning Banners
-  - 1.8.1.1 Ensure message of the day is configured properly (Automated)
-  - 1.8.1.2 Ensure local login warning banner is configured properly - (Automated) 115
-  - 1.8.1.3 Ensure remote login warning banner is configured properly - (Automated)
-  - 1.8.1.4 Ensure permissions on /etc/motd are configured (Automated)
-  - 1.8.1.5 Ensure permissions on /etc/issue are configured (Automated)
-  - 1.8.1.6 Ensure permissions on /etc/issue.net are configured - (Automated)
-  - 1.9 Ensure updates, patches, and additional security software are - installed (Manual)
-  - 1.10 Ensure GDM is removed or login is configured (Automated)
+**1.9 Ensure updates, patches, and additional security software are installed (Automated)**
 
 **2 Services**
   - 2.1 inetd Services

--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -520,62 +520,8 @@
     - level_1_workstation
     - 1.2.2
     - manual
-# 1.3 Configure sudo
-# sudo allows a permitted user to execute a command as the superuser or another user, as
-# specified by the security policy. The invoking user's real (not effective) user ID is used to
-# determine the user name with which to query the security policy.
-# sudo supports a plugin architecture for security policies and input/output logging. Third
-# parties can develop and distribute their own policy and I/O logging plugins to work
-# seamlessly with the sudo front end. The default security policy is sudoers, which is
-# configured via the file /etc/sudoers.
-# 1.3.1 Ensure sudo is installed
-- name: 1.3.1 Ensure sudo is installed
-  apt:
-    name: sudo
-    state: present
-    install_recommends: false
-  tags:
-    - section1
-    - level_1_server
-    - level_1_workstation
-    - 1.3.1
-# 1.3.2 Ensure sudo commands use pty
-# sudo can be configured to run only from a pseudo-pty
-# Note: visudo edits the sudoers file in a safe fashion, analogous to vipw(8). visudo locks the
-# sudoers file against multiple simultaneous edits, provides basic sanity checks, and checks or
-# parse errors. If the sudoers file is currently being edited you will receive a message to try
-# again later.
-- name: 1.3.2 Ensure sudo commands use pty
-  lineinfile:
-    dest: /etc/sudoers
-    state: present
-    regexp: "^Defaults use_pty"
-    line: "Defaults use_pty"
-    validate: "visudo -cf %s"
-  tags:
-    - section1
-    - level_1_server
-    - level_1_workstation
-    - 1.3.2
-# 1.3.3 Ensure sudo log file exists
-# sudo can use a custom log file.
-# Note: visudo edits the sudoers file in a safe fashion, analogous to vipw(8). visudo locks the
-# sudoers file against multiple simultaneous edits, provides basic sanity checks, and checks or
-# parse errors. If the sudoers file is currently being edited you will receive a message to try
-# again later.
-- name: 1.3.3 Ensure sudo log file exists
-  lineinfile:
-    dest: /etc/sudoers
-    state: present
-    regexp: "^Defaults logfile.*"
-    line: 'Defaults logfile="/var/log/sudo.log"'
-    validate: "visudo -cf %s"
-  tags:
-    - section1
-    - level_1_server
-    - level_1_workstation
-    - 1.3.3
-# 1.4 Filesystem Integrity Checking
+
+# 1.3 Filesystem Integrity Checking
 # AIDE is a file integrity checking tool, similar in nature to Tripwire. While it cannot prevent
 # intrusions, it can detect unauthorized changes to configuration files by alerting when the
 # files are changed. When setting up AIDE, decide internally what the site policy will be
@@ -622,7 +568,7 @@
     - section1
     - level_1_server
     - level_1_workstation
-    - 1.4.1
+    - 1.3.1
 # 1.3.2 Ensure filesystem integrity is regularly checked
 # Periodic checking of the filesystem integrity is needed to detect changes to the filesystem.
 # Notes:
@@ -649,7 +595,7 @@
     - 1.3.2
 
 
-# 1.5 Secure Boot Settings
+# 1.4 Secure Boot Settings
 # The recommendations in this section focus on securing the bootloader and settings
 # involved in the boot process directly.
 

--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -137,9 +137,13 @@
     - 5.1.9
 
 # 5.2 Configure sudo
-# sudo allows a permitted user to execute a command as the superuser or another user,
-# as specified by the security policy. The invoking user's real (not effective)
-# user ID is used to determine the user name with which to query the security policy
+# sudo allows a permitted user to execute a command as the superuser or another user, as
+# specified by the security policy. The invoking user's real (not effective) user ID is used to
+# determine the user name with which to query the security policy.
+# sudo supports a plugin architecture for security policies and input/output logging. Third
+# parties can develop and distribute their own policy and I/O logging plugins to work
+# seamlessly with the sudo front end. The default security policy is sudoers, which is
+# configured via the file /etc/sudoers.
 - name: 5.2.1 Ensure sudo is installed
   apt:
     name: sudo
@@ -150,12 +154,42 @@
     - level_1_server
     - level_1_workstation
     - 5.2.1
-# - name: 5.2.2 Ensure sudo commands use pty
-# Edit the file /etc/sudoers or a file in /etc/sudoers.d/ with visudo -f and add the following line
-# Defaults use_pty
-# - name: 5.2.3 Ensure sudo log file exists
-# Edit the file /etc/sudoers or a file in /etc/sudoers.d/ with visudo -f and add the following line: and add the following line:
-# Defaults logfile="/var/log/sudo.log"
+# 5.2.2 Ensure sudo commands use pty
+# sudo can be configured to run only from a pseudo-pty
+# Note: visudo edits the sudoers file in a safe fashion, analogous to vipw(8). visudo locks the
+# sudoers file against multiple simultaneous edits, provides basic sanity checks, and checks or
+# parse errors. If the sudoers file is currently being edited you will receive a message to try
+# again later.
+- name: 5.2.2 Ensure sudo commands use pty
+  lineinfile:
+    dest: /etc/sudoers
+    state: present
+    regexp: "^Defaults use_pty"
+    line: "Defaults use_pty"
+    validate: "visudo -cf %s"
+  tags:
+    - section5
+    - level_1_server
+    - level_1_workstation
+    - 5.2.2
+# 5.2.3 Ensure sudo log file exists
+# sudo can use a custom log file.
+# Note: visudo edits the sudoers file in a safe fashion, analogous to vipw(8). visudo locks the
+# sudoers file against multiple simultaneous edits, provides basic sanity checks, and checks or
+# parse errors. If the sudoers file is currently being edited you will receive a message to try
+# again later.
+- name: 5.2.3 Ensure sudo log file exists
+  lineinfile:
+    dest: /etc/sudoers
+    state: present
+    regexp: "^Defaults logfile.*"
+    line: 'Defaults logfile="/var/log/sudo.log"'
+    validate: "visudo -cf %s"
+  tags:
+    - section5
+    - level_1_server
+    - level_1_workstation
+    - 5.2.3
 
 # 5.3 Configure SSH Server
 # 5.3.1 Ensure permissions on /etc/ssh/sshd_config are configured


### PR DESCRIPTION
Task "Ensure sudo is installed" got moved around in the latest CIS to 5.2.1. This PR fixes the consistency.