### PR TITLE
fix for ipv6 logic

### DIFF
--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -21,7 +21,7 @@
         - { name: net.ipv6.conf.all.disable_ipv6, value: 1 }
         - { name: net.ipv6.conf.default.disable_ipv6, value: 1 }
         - { name: net.ipv6.route.flush, value: 1 }
-  when: IPv6_is_enabled is defined and not IPv6_is_enabled
+  when: IPv6_is_enabled
   tags:
     - section3
     - level_2_server


### PR DESCRIPTION
Previous version was not working as expected, because if `IPV6_is_enabled` was false (as it is by default), this condition would execute (because of `not IPV6_is_enabled`) and write `/etc/sysctl.conf`, causing an error.

Manual execution is the following:

```
$ sudo sysctl net.ipv6.conf.all.disable_ipv6=1
sysctl: cannot stat /proc/sys/net/ipv6/conf/all/disable_ipv6: No such file or directory
```

Ansible execution is the following 
```
TASK [CIS-Ubuntu-20.04-Ansible : 3.1.1 Disable IPv6] **************************************************************************************************************************************

failed: [node-1] (item={'name': 'net.ipv6.conf.all.disable_ipv6', 'value': 1}) => {"ansible_loop_var": "item", "changed": false, "item": {"name": "net.ipv6.conf.all.disable_ipv6", "value": 1}, "msg": "Failed to reload sysctl: kernel.randomize_va_space = 2\nnet.ipv4.conf.all.send_redirects = 0\nnet.ipv4.conf.default.send_redirects = 0\nnet.ipv4.conf.all.accept_source_route = 0\nnet.ipv4.conf.default.accept_source_route = 0\nnet.ipv4.conf.all.accept_redirects = 0\nnet.ipv4.conf.default.accept_redirects = 0\nnet.ipv4.conf.all.secure_redirects = 0\nnet.ipv4.conf.default.secure_redirects = 0\nnet.ipv4.conf.all.log_martians = 1\nnet.ipv4.conf.default.log_martians = 1\nnet.ipv4.icmp_echo_ignore_broadcasts = 1\nnet.ipv4.icmp_ignore_bogus_error_responses = 1\nnet.ipv4.tcp_syncookies = 1\nfs.suid_dumpable = 0\nsysctl: cannot stat /proc/sys/net/ipv6/conf/all/disable_ipv6: No such file or directory\nsysctl: cannot stat /proc/sys/net/ipv6/conf/default/disable_ipv6: No such file or directory\nsysctl: cannot stat /proc/sys/net/ipv6/route/flush: No such file or directory\n"}

failed: [node-1] (item={'name': 'net.ipv6.conf.default.disable_ipv6', 'value': 1}) => {"ansible_loop_var": "item", "changed": false, "item": {"name": "net.ipv6.conf.default.disable_ipv6", "value": 1}, "msg": "Failed to reload sysctl: kernel.randomize_va_space = 2\nnet.ipv4.conf.all.send_redirects = 0\nnet.ipv4.conf.default.send_redirects = 0\nnet.ipv4.conf.all.accept_source_route = 0\nnet.ipv4.conf.default.accept_source_route = 0\nnet.ipv4.conf.all.accept_redirects = 0\nnet.ipv4.conf.default.accept_redirects = 0\nnet.ipv4.conf.all.secure_redirects = 0\nnet.ipv4.conf.default.secure_redirects = 0\nnet.ipv4.conf.all.log_martians = 1\nnet.ipv4.conf.default.log_martians = 1\nnet.ipv4.icmp_echo_ignore_broadcasts = 1\nnet.ipv4.icmp_ignore_bogus_error_responses = 1\nnet.ipv4.tcp_syncookies = 1\nfs.suid_dumpable = 0\nsysctl: cannot stat /proc/sys/net/ipv6/conf/all/disable_ipv6: No such file or directory\nsysctl: cannot stat /proc/sys/net/ipv6/conf/default/disable_ipv6: No such file or directory\nsysctl: cannot stat /proc/sys/net/ipv6/route/flush: No such file or directory\n"}

failed: [node-1] (item={'name': 'net.ipv6.route.flush', 'value': 1}) => {"ansible_loop_var": "item", "changed": false, "item": {"name": "net.ipv6.route.flush", "value": 1}, "msg": "Failed to reload sysctl: kernel.randomize_va_space = 2\nnet.ipv4.conf.all.send_redirects = 0\nnet.ipv4.conf.default.send_redirects = 0\nnet.ipv4.conf.all.accept_source_route = 0\nnet.ipv4.conf.default.accept_source_route = 0\nnet.ipv4.conf.all.accept_redirects = 0\nnet.ipv4.conf.default.accept_redirects = 0\nnet.ipv4.conf.all.secure_redirects = 0\nnet.ipv4.conf.default.secure_redirects = 0\nnet.ipv4.conf.all.log_martians = 1\nnet.ipv4.conf.default.log_martians = 1\nnet.ipv4.icmp_echo_ignore_broadcasts = 1\nnet.ipv4.icmp_ignore_bogus_error_responses = 1\nnet.ipv4.tcp_syncookies = 1\nfs.suid_dumpable = 0\nsysctl: cannot stat /proc/sys/net/ipv6/conf/all/disable_ipv6: No such file or directory\nsysctl: cannot stat /proc/sys/net/ipv6/conf/default/disable_ipv6: No such file or directory\nsysctl: cannot stat /proc/sys/net/ipv6/route/flush: No such file or directory\n"}
```