### PR TITLE
fixing umask_value to be a string

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -155,7 +155,7 @@ account_inactive: 30
 ## 5.4.5 Ensure default user shell timeout is 900 seconds or less
 shell_timeout_sec: 900
 ## 5.5.4 Ensure default user umask is 027 or more restrictive
-umask_value: 027 # Adds the option to declare the umask preferred value, with 027 as default
+umask_value: "027" # Adds the option to declare the umask preferred value, with 027 as default
 ## In some particular use cases (e.g. installing and using new python packages after 
 ## hardening), it is required that umask permissions were not as strict as 
 ## 027, because the system will not be able to run the newer python packages. 


### PR DESCRIPTION
Latest PR had a typo, umask_value should be "027" instead of 027 because its value is not taken as a string, 