### PR TITLE
bugfix(3.1.1,4.1.1.3,4.1.1.4): Executes `update-grub` after modifying `/etc/default/grub`.

### DIFF
--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -5,12 +5,14 @@
 # If IPv6 or dual stack is not to be used, it is recommended that IPv6 be disabled to reduce the attack surface of the system.
 - name: 3.1.1 Disable IPv6
   block:
-    - name: 3.1.1 Disable IPv6
+    - name: 3.1.1 Disable IPv6 - change /etc/default/grub
       replace:
         dest: /etc/default/grub
         regexp: '^(GRUB_CMDLINE_LINUX=(?!.*ipv6.disable)\"[^\"]*)(\".*)'
         replace: '\1 ipv6.disable=1\2'
-    - name: 3.1.1 Disable IPv6
+    - name: 3.1.1 Disable IPv6 - update grub
+      shell: update-grub
+    - name: 3.1.1 Disable IPv6 - change sysctl
       sysctl:
         name: "{{ item.name }}"
         value: "{{ item.value }}"

--- a/tasks/section_4_Logging_and_Auditing.yaml
+++ b/tasks/section_4_Logging_and_Auditing.yaml
@@ -27,24 +27,33 @@
     - level_2_workstation
     - 4.1.1.2
 # 4.1.1.3 Ensure auditing for processes that start prior to auditd is enabled
+# Audit events need to be captured on processes that start up prior to auditd , so that potential malicious activity cannot go undetected.
 - name: 4.1.1.3 Ensure auditing for processes that start prior to auditd is enabled
-  # Audit events need to be captured on processes that start up prior to auditd , so that potential malicious activity cannot go undetected.
-  replace:
-    dest: /etc/default/grub
-    regexp: '^(GRUB_CMDLINE_LINUX=(?!.*audit)\"[^\"]*)(\".*)'
-    replace: '\1 audit=1\2'
+  block:
+    - name: 4.1.1.3 Ensure auditing for processes that start prior to auditd is enabled - change /etc/default/grub
+      replace:
+        dest: /etc/default/grub
+        regexp: '^(GRUB_CMDLINE_LINUX=(?!.*audit)\"[^\"]*)(\".*)'
+        replace: '\1 audit=1\2'
+    - name: 4.1.1.3 Ensure auditing for processes that start prior to auditd is enabled - update grub
+      shell: update-grub
   tags:
     - section4
     - level_2_server
     - level_2_workstation
     - 4.1.1.3
 # 4.1.1.4 Ensure audit_backlog_limit is sufficient
-# during boot if audit=1, then the backlog will hold 64 records. If more that 64 records are created during boot, auditd records will be lost and potential malicious activity could go undetected.
+# During boot if audit=1, then the backlog will hold 64 records. If more that 64 records are created during boot,
+# auditd records will be lost and potential malicious activity could go undetected.
 - name: 4.1.1.4 Ensure audit_backlog_limit is sufficient
-  replace:
-    dest: /etc/default/grub
-    regexp: '^(GRUB_CMDLINE_LINUX=(?!.*audit_backlog_limit)\"[^\"]*)(\".*)'
-    replace: '\1 audit_backlog_limit={{grub_backlog_limit}}\2'
+  block:
+    - name: 4.1.1.4 Ensure audit_backlog_limit is sufficient - change /etc/default/grub
+      replace:
+        dest: /etc/default/grub
+        regexp: '^(GRUB_CMDLINE_LINUX=(?!.*audit_backlog_limit)\"[^\"]*)(\".*)'
+        replace: '\1 audit_backlog_limit={{grub_backlog_limit}}\2'
+    - name: 4.1.1.4 Ensure audit_backlog_limit is sufficient - update grub
+      shell: update-grub
   tags:
     - section4
     - level_2_server


### PR DESCRIPTION
After touching `/etc/default/grub`, `update-grub` should be executed in tasks 3.1.1,4.1.1.3,4.1.1.4.


Note: I have a doubt with the `when` clause in  3.1.1:

`when: IPv6_is_enabled`

Shouldn't it be  `when: not IPv6_is_enabled` ? (even though it seems that if a priori no IPv6 is available, the `sysctl` commands fail)