### PR TITLE
bugfix(3.1.1): Task 3.1.1 should only run when IPv6 is NOT enabled

### DIFF
--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -19,11 +19,12 @@
         sysctl_set: true
         state: present
         reload: true
+      ignore_errors: true
       with_items:
         - { name: net.ipv6.conf.all.disable_ipv6, value: 1 }
         - { name: net.ipv6.conf.default.disable_ipv6, value: 1 }
         - { name: net.ipv6.route.flush, value: 1 }
-  when: IPv6_is_enabled
+  when: not IPv6_is_enabled
   tags:
     - section3
     - level_2_server


### PR DESCRIPTION
bugfix(3.1.1): Task 3.1.1 should only run when IPv6 is NOT enabled. Right now it states `when: IPv6_is_enabled`

Also, the CIS documentation states to switch off IPv6 OR through grub, or through `sysctl`. If a priori IPv6 was already disabled, the `sysctl` commands throw an error, hence an `ignore_errors: true` was added in that subtask:

```
TASK [CIS-Ubuntu-20.04-Ansible : 3.1.1 Disable IPv6 - change sysctl] *****************************************************************************************
failed: [node-1] (item={u'name': u'net.ipv6.conf.all.disable_ipv6', u'value': 1}) => {"ansible_loop_var": "item", "changed": false, "item": {"name": "net.ipv6.conf.all.disable_ipv6", "value": 1}, "msg": "Failed to reload sysctl: net.ipv4.conf.all.accept_redirects = 0\nnet.ipv4.conf.default.accept_redirects = 0\nkernel.randomize_va_space = 2\nfs.suid_dumpable = 0\nnet.ipv4.conf.all.send_redirects = 0\nnet.ipv4.conf.default.send_redirects = 0\nnet.ipv4.conf.all.accept_source_route = 0\nnet.ipv4.conf.default.accept_source_route = 0\nnet.ipv4.conf.all.secure_redirects = 0\nnet.ipv4.conf.default.secure_redirects = 0\nnet.ipv4.conf.all.log_martians = 1\nnet.ipv4.conf.default.log_martians = 1\nnet.ipv4.icmp_echo_ignore_broadcasts = 1\nnet.ipv4.ip_forward = 0\nnet.ipv4.icmp_ignore_bogus_error_responses = 1\nnet.ipv4.tcp_syncookies = 1\nsysctl: cannot stat /proc/sys/net/ipv6/conf/all/disable_ipv6: No such file or directory\nsysctl: cannot stat /proc/sys/net/ipv6/conf/default/disable_ipv6: No such file or directory\nsysctl: cannot stat /proc/sys/net/ipv6/route/flush: No such file or directory\n"}
failed: [node-1] (item={u'name': u'net.ipv6.conf.default.disable_ipv6', u'value': 1}) => {"ansible_loop_var": "item", "changed": false, "item": {"name": "net.ipv6.conf.default.disable_ipv6", "value": 1}, "msg": "Failed to reload sysctl: net.ipv4.conf.all.accept_redirects = 0\nnet.ipv4.conf.default.accept_redirects = 0\nkernel.randomize_va_space = 2\nfs.suid_dumpable = 0\nnet.ipv4.conf.all.send_redirects = 0\nnet.ipv4.conf.default.send_redirects = 0\nnet.ipv4.conf.all.accept_source_route = 0\nnet.ipv4.conf.default.accept_source_route = 0\nnet.ipv4.conf.all.secure_redirects = 0\nnet.ipv4.conf.default.secure_redirects = 0\nnet.ipv4.conf.all.log_martians = 1\nnet.ipv4.conf.default.log_martians = 1\nnet.ipv4.icmp_echo_ignore_broadcasts = 1\nnet.ipv4.ip_forward = 0\nnet.ipv4.icmp_ignore_bogus_error_responses = 1\nnet.ipv4.tcp_syncookies = 1\nsysctl: cannot stat /proc/sys/net/ipv6/conf/all/disable_ipv6: No such file or directory\nsysctl: cannot stat /proc/sys/net/ipv6/conf/default/disable_ipv6: No such file or directory\nsysctl: cannot stat /proc/sys/net/ipv6/route/flush: No such file or directory\n"}
failed: [node-1] (item={u'name': u'net.ipv6.route.flush', u'value': 1}) => {"ansible_loop_var": "item", "changed": false, "item": {"name": "net.ipv6.route.flush", "value": 1}, "msg": "Failed to reload sysctl: net.ipv4.conf.all.accept_redirects = 0\nnet.ipv4.conf.default.accept_redirects = 0\nkernel.randomize_va_space = 2\nfs.suid_dumpable = 0\nnet.ipv4.conf.all.send_redirects = 0\nnet.ipv4.conf.default.send_redirects = 0\nnet.ipv4.conf.all.accept_source_route = 0\nnet.ipv4.conf.default.accept_source_route = 0\nnet.ipv4.conf.all.secure_redirects = 0\nnet.ipv4.conf.default.secure_redirects = 0\nnet.ipv4.conf.all.log_martians = 1\nnet.ipv4.conf.default.log_martians = 1\nnet.ipv4.icmp_echo_ignore_broadcasts = 1\nnet.ipv4.ip_forward = 0\nnet.ipv4.icmp_ignore_bogus_error_responses = 1\nnet.ipv4.tcp_syncookies = 1\nsysctl: cannot stat /proc/sys/net/ipv6/conf/all/disable_ipv6: No such file or directory\nsysctl: cannot stat /proc/sys/net/ipv6/conf/default/disable_ipv6: No such file or directory\nsysctl: cannot stat /proc/sys/net/ipv6/route/flush: No such file or directory\n"}
```