### PR TITLE
bugfix(3.1.1): Avoids occasional errors, when IPv6 is already disabled.

### DIFF
--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -20,10 +20,27 @@
         state: present
         reload: true
       ignore_errors: true
+      register: result_disable_ipv6_sysctl
       with_items:
         - { name: net.ipv6.conf.all.disable_ipv6, value: 1 }
         - { name: net.ipv6.conf.default.disable_ipv6, value: 1 }
         - { name: net.ipv6.route.flush, value: 1 }
+      # IF IPv6 is disabled in GRUB, above task will fail but leave /etc/sysctl dirty, preventing sysctl
+      # configurations in other tasks.
+      # In the below task, the last iteration will leave the sysctl file cleaned up.
+    - name: 3.1.1 Disable IPv6 - recover sysctl
+      sysctl:
+        name: "{{ item.name }}"
+        value: "{{ item.value }}"
+        state: absent
+        reload: true
+      ignore_errors: true
+      with_items:
+        - { name: net.ipv6.conf.all.disable_ipv6, value: 1 }
+        - { name: net.ipv6.conf.default.disable_ipv6, value: 1 }
+        - { name: net.ipv6.route.flush, value: 1 }
+      when: result_disable_ipv6_sysctl.failed
+
   when: not IPv6_is_enabled
   tags:
     - section3


### PR DESCRIPTION
In some cases, executing task 3.1.1 throws error, because the reload of `sysctl` doesn't work if the file already has lines with ipv6 stuff and IPv6 has been disabled.

This PR adds a check to overcome this.