### PR TITLE
chore: Adds a pre-emptive 'apt update'

### DIFF
--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -11,7 +11,17 @@
 #       fail:
 #         msg: "Exiting: Change root_password from r00tP4ssw0rd in defaults/main.yml"
 #   when: set_root_password and root_password is match ("r00tP4ssw0rd")
-  
+
+- name: 1.0 Pre-emptively run an 'apt update', so that future 'apt' invocations don't need to do it anymore
+  apt:
+    force_apt_get: yes
+    update_cache: yes
+  tags:
+    - section1
+    - level_1_server
+    - level_1_workstation
+    - "1.0"
+
 # 1.1.1 Disable unused filesystems
 # 1.1.1.1 Ensure mounting of cramfs filesystems is disabled
 # Removing support for unneeded filesystem types reduces the local attack surface of the


### PR DESCRIPTION
Many tasks do an apt install without an apt update, which may cause "Unable to fetch some archives" errors if the upstream .debs have changed.

```
whitestack@TC-MXTLNE1-INFR001:~$ sudo apt install systemd-coredump
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following packages were automatically installed and are no longer required:
  alembic cinder-common docutils-common ieee-data javascript-common libblas3 libevent-core-2.1-7 libevent-pthreads-2.1-7 libgfortran5 libimagequant0 libisns0 libjbig0 libjpeg-turbo8 libjpeg8 libjs-jquery libjs-sphinxdoc
  libjs-underscore liblapack3 liblcms2-2 libopts25 libpaper-utils libpaper1 libpq5 libtiff5 libwebp6 libwebpdemux2 libwebpmux3 os-brick-common pycadf-common python-babel-localedata python-pastedeploy-tpl python3-alembic
  python3-amqp python3-anyjson python3-attr python3-automaton python3-babel python3-barbicanclient python3-bcrypt python3-blinker python3-bs4 python3-cachetools python3-castellan python3-cffi python3-cliff python3-cmd2
  python3-cursive python3-dateutil python3-ddt python3-debtcollector python3-defusedxml python3-dnspython python3-docutils python3-dogpile.cache python3-eventlet python3-extras python3-fasteners python3-fixtures
  python3-futurist python3-glanceclient python3-greenlet python3-html5lib python3-httplib2 python3-importlib-metadata python3-iso8601 python3-jinja2 python3-json-pointer python3-jsonpatch python3-jsonschema python3-jwt
  python3-kazoo python3-keystoneauth1 python3-keystoneclient python3-keystonemiddleware python3-kombu python3-linecache2 python3-lxml python3-mako python3-markupsafe python3-memcache python3-migrate python3-mimeparse
  python3-monotonic python3-more-itertools python3-msgpack python3-netaddr python3-networkx python3-novaclient python3-numpy python3-oauthlib python3-olefile python3-os-service-types python3-os-win python3-oslo.cache
  python3-oslo.concurrency python3-oslo.config python3-oslo.context python3-oslo.db python3-oslo.i18n python3-oslo.log python3-oslo.messaging python3-oslo.middleware python3-oslo.policy python3-oslo.privsep
  python3-oslo.reports python3-oslo.rootwrap python3-oslo.serialization python3-oslo.service python3-oslo.upgradecheck python3-oslo.utils python3-oslo.versionedobjects python3-oslo.vmware python3-osprofiler
  python3-paramiko python3-paste python3-pastedeploy python3-pastescript python3-pbr python3-pil python3-ply python3-prettytable python3-psutil python3-psycopg2 python3-pycadf python3-pycparser python3-pygments
  python3-pyinotify python3-pymemcache python3-pymysql python3-pyparsing python3-pyperclip python3-pyrsistent python3-redis python3-repoze.lru python3-retrying python3-rfc3986 python3-roman python3-routes
  python3-simplejson python3-soupsieve python3-sqlalchemy python3-sqlalchemy-ext python3-sqlparse python3-statsd python3-stevedore python3-suds python3-swiftclient python3-tabulate python3-taskflow python3-tempita
  python3-tenacity python3-testresources python3-testscenarios python3-testtools python3-tooz python3-traceback2 python3-tz python3-unittest2 python3-vine python3-voluptuous python3-warlock python3-wcwidth
  python3-webencodings python3-webob python3-wrapt python3-zake python3-zipp python3-zope.interface sgml-base sntp xml-core
Use 'sudo apt autoremove' to remove them.
The following additional packages will be installed:
  libdw1
The following NEW packages will be installed:
  libdw1 systemd-coredump
0 upgraded, 2 newly installed, 0 to remove and 214 not upgraded.
Need to get 43.7 kB/269 kB of archives.
After this operation, 1,275 kB of additional disk space will be used.
Do you want to continue? [Y/n] y
Err:1 http://nova.clouds.archive.ubuntu.com/ubuntu focal-updates/universe amd64 systemd-coredump amd64 245.4-4ubuntu3.17
  404  Not Found [IP: 10.218.14.157 3142]
E: Failed to fetch http://nova.clouds.archive.ubuntu.com/ubuntu/pool/universe/s/systemd/systemd-coredump_245.4-4ubuntu3.17_amd64.deb  404  Not Found [IP: 10.218.14.157 3142]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

This PR adds a new task, 1., which runs a pre-emptive `apt update`.