### PR TITLE
bugfix(5.3.10): Corrects "Match Address" section placement in ssh config file

### DIFF
--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -371,6 +371,7 @@
         dest: /etc/ssh/sshd_config
         regexp: "^[Mm]atch [Aa]ddress.*\n*PermitRootLogin.*"
         line: "Match address {{ ssh_root_login_ips }}\n PermitRootLogin yes"
+        insertafter: "EOF"
       when: (ssh_root_login_ips != "None") and (ssh_root_login_ips|length > 0)
   tags:
   - section5


### PR DESCRIPTION
If a `Match Address` is added in the middle of the `/etc/ssh/sshd_config` file, the ssh daemon can't be restarted.

Cf. https://unix.stackexchange.com/questions/573792/match-user-placement-in-sshd-config

A quick fix is adding the section at the end of the file.