### PR TITLE
bugfix(5.3.10): Corrects previous fix

### DIFF
--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -364,14 +364,12 @@
     - name: "5.3.10 Ensure SSH root login is disabled: remove root login for all existing IPs"
       replace:
         dest: /etc/ssh/sshd_config
-        regexp: "^[Mm]atch [Aa]ddress.*\n.*PermitRootLogin.*$"
+        regexp: "^[Mm]atch [Aa]ddress.*\n[ ]*PermitRootLogin.*(\n[Mm]atch [Aa]ll[ ]*)?\n"
     - name: "5.3.10 Ensure SSH root login is disabled: allow ssh root login from '{{ ssh_root_login_ips }}'"
       lineinfile:
         state: present
         dest: /etc/ssh/sshd_config
-        regexp: "^[Mm]atch [Aa]ddress.*\n*PermitRootLogin.*"
-        line: "Match address {{ ssh_root_login_ips }}\n PermitRootLogin yes"
-        insertafter: "EOF"
+        line: "Match Address {{ ssh_root_login_ips }}\n  PermitRootLogin yes\nMatch All"
       when: (ssh_root_login_ips != "None") and (ssh_root_login_ips|length > 0)
   tags:
   - section5


### PR DESCRIPTION
The previous fix for 5.3.10 (adding the `PermitRootLogin` section at the end of the ssh config file) didn't work well together with the other tasks in the playbook, because those tasks append other lines to the files, so the "Match" section still remains "unclosed" and the ssh daemon can’t restart.
The new fix now closes the "Match" section with a "Match All", so that it can be placed in the middle of the file.

