### PR TITLE
chore: Adds a new flag to toggle the disabling of IPv6 through Grub

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -93,8 +93,12 @@ remove_RPC: yes
 
 
 # Section 3 Settings
-disable_wifi: no
+# 3.1.1 Disable IPv6
+## General flag to enable IPv6 in grub and /etc/sysctl.conf
 IPv6_is_enabled: no
+## Can be used to only disable IPv6 in sysctl and not in Grub (useful when other apps set IPv6 values in /etc/sysctl.conf).
+disable_IPv6_in_grub: "{{ not IPv6_is_enabled }}"
+disable_wifi: no
 enable_firewall: yes
 UFWEnable: yes # Running both ufw and the services included in the iptables-persistent package may lead to conflict
 ## 3.5.1.6 Ensure firewall rules exist for all open ports | defined ports

--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -5,15 +5,20 @@
 # If IPv6 or dual stack is not to be used, it is recommended that IPv6 be disabled to reduce the attack surface of the system.
 - name: 3.1.1 Disable IPv6
   block:
-    - name: 3.1.1 Disable IPv6 - change /etc/default/grub
+    - name: 3.1.1 Disable IPv6 - change /etc/default/grub to disable IPv6
       replace:
         dest: /etc/default/grub
         regexp: '^(GRUB_CMDLINE_LINUX=(?!.*ipv6.disable)\"[^\"]*)(\".*)'
         replace: '\1 ipv6.disable=1\2'
       when: disable_IPv6_in_grub
+    - name: 3.1.1 Disable IPv6 - change /etc/default/grub to remove disabling IPv6
+      replace:
+        dest: /etc/default/grub
+        regexp: '^(GRUB_CMDLINE_LINUX=".*) ipv6.disable=1(.*")$'
+        replace: '\1\2'
+      when: not disable_IPv6_in_grub
     - name: 3.1.1 Disable IPv6 - update grub
       shell: update-grub
-      when: disable_IPv6_in_grub
     - name: 3.1.1 Disable IPv6 - change sysctl
       sysctl:
         name: "{{ item.name }}"

--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -10,8 +10,10 @@
         dest: /etc/default/grub
         regexp: '^(GRUB_CMDLINE_LINUX=(?!.*ipv6.disable)\"[^\"]*)(\".*)'
         replace: '\1 ipv6.disable=1\2'
+      when: disable_IPv6_in_grub
     - name: 3.1.1 Disable IPv6 - update grub
       shell: update-grub
+      when: disable_IPv6_in_grub
     - name: 3.1.1 Disable IPv6 - change sysctl
       sysctl:
         name: "{{ item.name }}"
@@ -25,22 +27,7 @@
         - { name: net.ipv6.conf.all.disable_ipv6, value: 1 }
         - { name: net.ipv6.conf.default.disable_ipv6, value: 1 }
         - { name: net.ipv6.route.flush, value: 1 }
-      # IF IPv6 is disabled in GRUB, above task will fail but leave /etc/sysctl dirty, preventing sysctl
-      # configurations in other tasks.
-      # In the below task, the last iteration will leave the sysctl file cleaned up.
-    - name: 3.1.1 Disable IPv6 - recover sysctl
-      sysctl:
-        name: "{{ item.name }}"
-        value: "{{ item.value }}"
-        state: absent
-        reload: true
-      ignore_errors: true
-      with_items:
-        - { name: net.ipv6.conf.all.disable_ipv6, value: 1 }
-        - { name: net.ipv6.conf.default.disable_ipv6, value: 1 }
-        - { name: net.ipv6.route.flush, value: 1 }
-      when: result_disable_ipv6_sysctl.failed
-
+      when: not disable_IPv6_in_grub
   when: not IPv6_is_enabled
   tags:
     - section3


### PR DESCRIPTION
The flag `IPv6_is_enabled` disables IPv6 through Grub AND in the /etc/sysctl.conf file, which causes problems rerunning the hardening after a reboot, because the config file shouldn't contain entries for IPv6 if IPv6 is already disabled through Grub, and in that case the second part of the block fails. Previously we added a rough workaround for that, but in the end a new flag seems better (and also allows for personalizing).

The block becomes:
```
  block:
    - name: 3.1.1 Disable IPv6 - change /etc/default/grub
      replace:
        dest: /etc/default/grub
        regexp: '^(GRUB_CMDLINE_LINUX=(?!.*ipv6.disable)\"[^\"]*)(\".*)'
        replace: '\1 ipv6.disable=1\2'
      when: disable_IPv6_in_grub
    - name: 3.1.1 Disable IPv6 - update grub
      shell: update-grub
      when: disable_IPv6_in_grub
    - name: 3.1.1 Disable IPv6 - change sysctl
      sysctl:
        name: "{{ item.name }}"
        value: "{{ item.value }}"
        sysctl_set: true
        state: present
        reload: true
      ignore_errors: true
      register: result_disable_ipv6_sysctl
      with_items:
        - { name: net.ipv6.conf.all.disable_ipv6, value: 1 }
        - { name: net.ipv6.conf.default.disable_ipv6, value: 1 }
        - { name: net.ipv6.route.flush, value: 1 }
      when: not disable_IPv6_in_grub
  when: not IPv6_is_enabled
```