### PR TITLE
bugfix(5.4.1): Installs a missing package so that password quality check doesn't fail

### DIFF
--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -559,7 +559,9 @@
   block:
     - name: 5.4.1 Ensure password creation requirements are configured
       apt:
-        name: libpam-pwquality
+        name:
+          - libpam-pwquality
+          - cracklib-runtime
         state: present
         install_recommends: false
     - name: 5.4.1 Ensure password creation requirements are configured


### PR DESCRIPTION
If package `libpam-pwquality` isn't available on target machine, the passwd quality check fails:
```
ubuntu@hardening:~$ sudo apt-get remove  -y  cracklib-runtime
...
0 upgraded, 0 newly installed, 0 to remove and 92 not upgraded.
ubuntu@hardening:~$ sudo passwd ubuntu
New password: 
/var/cache/cracklib/cracklib_dict.pwd.gz: No such file or directory
BAD PASSWORD: The password fails the dictionary check - error loading dictionary
Retype new password: 
```

After reinstalling:
```
sudo passwd ubuntu
New password: 
Retype new password: 
Password has been already used.
passwd: password updated successfully
```