### PR TITLE
Make IP forwarding and firewall allowing DNS configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -99,6 +99,8 @@ IPv6_is_enabled: no
 ## Can be used to only disable IPv6 in sysctl and not in Grub (useful when other apps set IPv6 values in /etc/sysctl.conf).
 disable_IPv6_in_grub: "{{ not IPv6_is_enabled }}"
 disable_wifi: no
+## IP Forwarding must be enabled if you're running eg. Docker
+IP_forwarding: no
 enable_firewall: yes
 UFWEnable: yes # Running both ufw and the services included in the iptables-persistent package may lead to conflict
 ## 3.5.1.6 Ensure firewall rules exist for all open ports | defined ports
@@ -106,6 +108,8 @@ firewall_list_of_ports_to_allow:
   - { rule: "allow", port: "8080", proto: "tcp" }
 ## 3.5.1.6 Ensure firewall rules exist for all open ports | keep_alived
 firewall_allow_keep_alive: no
+## 3.5.1.6 Ensure firewall rules exist for all open ports | dns
+firewall_allow_dns: yes
 
 # Section 4 Settings
 ## Ensure rsyslog is configured to send logs to a remote log host

--- a/tasks/section_3_Network_Configuration.yaml
+++ b/tasks/section_3_Network_Configuration.yaml
@@ -104,6 +104,7 @@
     - name: 3.2.2 Ensure IP forwarding is disabled | IPV6 load"
       script: 3_2_2_2.sh
       when: IPv6_is_enabled
+  when: not IP_forwarding
   tags:
     - section3
     - level_1_server
@@ -523,7 +524,6 @@
         name: ufw
         state: started
         enabled: true
-      when: UFWEnable
     - name: 3.5.1.3 Ensure ufw service is enabled | allow 22 before enable
       ufw:
         rule: "{{ item.rule }}"
@@ -605,6 +605,7 @@
       loop:
         - tcp
         - udp
+      when: firewall_allow_dns
     - name: 3.5.1.6 Ensure ufw firewall rules exist for all open ports | defined ports
       ufw:
         rule: "{{ item.rule }}"


### PR DESCRIPTION
Not everyone runs DNS and IP forwarding should be configurable since Docker and other container systems rely on it quite heavily.

Also removed a redundant UFWEnable (it was enabled on both the item and the block)