### PR TITLE
adding parameter in common-session

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -159,9 +159,6 @@ account_inactive: 30
 ## 5.4.5 Ensure default user shell timeout is 900 seconds or less
 shell_timeout_sec: 900
 ## 5.5.4 Ensure default user umask is 027 or more restrictive
-pam_common_session: true 
-## Adds parameter to enable (by default) or disable `sesion optional pam_umask.so` in `/etc/pam.d/common-session` 
-
 umask_value: "027" # Adds the option to declare the umask preferred value, with 027 as default
 ## In some particular use cases (e.g. installing and using new python packages after 
 ## hardening), it is required that umask permissions were not as strict as 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -159,6 +159,9 @@ account_inactive: 30
 ## 5.4.5 Ensure default user shell timeout is 900 seconds or less
 shell_timeout_sec: 900
 ## 5.5.4 Ensure default user umask is 027 or more restrictive
+pam_common_session: true 
+## Adds parameter to enable (by default) or disable `sesion optional pam_umask.so` in `/etc/pam.d/common-session` 
+
 umask_value: "027" # Adds the option to declare the umask preferred value, with 027 as default
 ## In some particular use cases (e.g. installing and using new python packages after 
 ## hardening), it is required that umask permissions were not as strict as 

--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -768,7 +768,7 @@
       lineinfile:
         dest: /etc/pam.d/common-session
         regexp: '^session optional\s+pam_umask.so'
-        line: "session optional  pam_umask.so"
+        line: "session optional pam_umask.so"
     - name: 5.5.4 Ensure default user umask is {{ umask_value | default('027') }} or more restrictive - /etc/bash.bashrc
       lineinfile:
         state: present

--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -769,6 +769,7 @@
         dest: /etc/pam.d/common-session
         regexp: '^session optional\s+'
         line: "session optional  pam_umask.so"
+      when: pam_common_session
     - name: 5.5.4 Ensure default user umask is {{ umask_value | default('027') }} or more restrictive - /etc/bash.bashrc
       lineinfile:
         state: present

--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -767,7 +767,7 @@
     - name: 5.5.4 Ensure default user umask is {{ umask_value | default('027') }} or more restrictive  | /etc/pam.d/common-session
       lineinfile:
         dest: /etc/pam.d/common-session
-        regexp: '^session optional\s+'
+        regexp: '^session optional\s+pam_umask.so'
         line: "session optional  pam_umask.so"
     - name: 5.5.4 Ensure default user umask is {{ umask_value | default('027') }} or more restrictive - /etc/bash.bashrc
       lineinfile:

--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -769,7 +769,6 @@
         dest: /etc/pam.d/common-session
         regexp: '^session optional\s+'
         line: "session optional  pam_umask.so"
-      when: pam_common_session
     - name: 5.5.4 Ensure default user umask is {{ umask_value | default('027') }} or more restrictive - /etc/bash.bashrc
       lineinfile:
         state: present


### PR DESCRIPTION
Adding parameter to enable (by default) or disable adding `sesion optional pam_umask.so` in `/etc/pam.d/common-session` 