### PR TITLE
Fixes password history requirement in PAM configuration

### DIFF
--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -611,6 +611,7 @@
   lineinfile:
     dest: /etc/pam.d/common-password
     line: "password required pam_pwhistory.so remember=5"
+    insertafter: '^password\s+?requisite.*'
   tags:
     - section5
     - level_1_server

--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -612,6 +612,8 @@
     dest: /etc/pam.d/common-password
     line: "password required pam_pwhistory.so remember=5"
     insertafter: '^password\s+?requisite.*'
+    state: present
+    firstmatch: true
   tags:
     - section5
     - level_1_server


### PR DESCRIPTION
- Improves 5.4.3: password history with 5 remembered passwords should be inserted after the existing password requisite line