### PR TITLE
Fixing 5.4.3 and 5.4.4

### DIFF
--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -626,6 +626,7 @@
     dest: /etc/pam.d/common-password
     regexp: '^password\s+\[success(.*)(md5|blowfish|bigcrypt|sha256|sha512)(.*)$'
     line: 'password [success\1 sha512 \3'
+    backrefs: true
   tags:
     - section5
     - level_1_server

--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -607,7 +607,19 @@
     - 5.4.2
 # 5.4.3 Ensure password reuse is limited
 # Locking out user IDs after n unsuccessful consecutive login attempts mitigates brute force password attacks against your systems.
-- name: 5.4.3 Ensure password reuse is limited
+
+- name: 5.4.3.1 Ensure password reuse is limited | delete possible duplicate lines
+  lineinfile:
+    dest: /etc/pam.d/common-password
+    regexp: '^password.*pam_pwhistory\.so.*remember.*'
+    state: absent
+  tags:
+    - section5
+    - level_1_server
+    - level_1_workstation
+    - 5.4.3
+
+- name: 5.4.3.2 Ensure password reuse is limited | update file according to CIS
   lineinfile:
     dest: /etc/pam.d/common-password
     line: "password required pam_pwhistory.so remember=5"
@@ -619,6 +631,7 @@
     - level_1_server
     - level_1_workstation
     - 5.4.3
+
 # 5.4.4 Ensure password hashing algorithm is SHA-512
 # The SHA-512 algorithm provides much stronger hashing than MD5, thus providing additional protection to the system by increasing the level of effort for an attacker to successfully determine passwords.
 - name: 5.4.4 Ensure password hashing algorithm is SHA-512


### PR DESCRIPTION
Tests Before fixing:
Literal values \1 and \3 were written

```
password        requisite                       pam_pwquality.so retry=3
password required pam_pwhistory.so remember=5
password [success\1 sha512 \3
```

Tests After Fixing: 
Capture groups \1 and \3 were honored

```
password	requisite			pam_pwquality.so retry=3
password required pam_pwhistory.so remember=5
password [success=1 default=ignore] pam_unix.so  sha512 
```

