### PR TITLE
chore(1.1.24): Adds small fixes to previous PR

### DIFF
--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -492,7 +492,7 @@
           register: kernel_modules_using_usb
         - name: 1.1.24 Disable USB Storage | disables the kernel modules that are using usb storage
           command: "modprobe -r {{ item }} usb_storage"
-          loop: "{{ kernel_modules_using_usb.stdout.split() | last | split(',') }}"
+          loop: "{{ kernel_modules_using_usb.stdout.split(' ') | last | split(',') }}"
           # The last column of the 'lsmod | grep -i usb_storage' command is a comma separated list of the kernel modules that are using usb_storage
           when: kernel_modules_using_usb.stdout | length > 0
       when: not disable_usb_kernel_modules

--- a/tasks/section_1_Initial_Setup.yaml
+++ b/tasks/section_1_Initial_Setup.yaml
@@ -495,7 +495,7 @@
           loop: "{{ kernel_modules_using_usb.stdout.split(' ') | last | split(',') }}"
           # The last column of the 'lsmod | grep -i usb_storage' command is a comma separated list of the kernel modules that are using usb_storage
           when: kernel_modules_using_usb.stdout | length > 0
-      when: not disable_usb_kernel_modules
+      when: disable_usb_kernel_modules
 
     - name: 1.1.24 Disable USB Storage
       modprobe:


### PR DESCRIPTION
although a whitespace is the default parameter for a split, it seems required for the build to be successful 

(in section 5 there are also uses of split where the whitespace as separator is explicitly specified)