### PR TITLE
bugfix(5.5.1.1+5.5.1.2+5.5.1.3): removes .split() as variable list_of_os_users is already a list

### DIFF
--- a/tasks/section_5_Access_Authentication_and_Authorization.yaml
+++ b/tasks/section_5_Access_Authentication_and_Authorization.yaml
@@ -676,7 +676,7 @@
 
     - name: 5.5.1.1 Ensure minimum days between password changes is configured  | chage --mindays
       command: "chage --mindays {{ pass_min_days }} {{ item }}"
-      loop: "{{ list_of_os_users.split(' ') }}"
+      loop: "{{ list_of_os_users }}"
 
     - name: 5.5.1.2 Ensure password expiration is 365 days or less | PASS_MAX_DAYS
       lineinfile:
@@ -687,7 +687,7 @@
 
     - name: 5.5.1.2 Ensure password expiration is 365 days or less  | chage
       command: "chage --maxdays {{ pass_expire_in_days }} {{ item }}"
-      loop: "{{ list_of_os_users.split(' ') }}"
+      loop: "{{ list_of_os_users }}"
 
     - name: 5.5.1.3 Ensure password expiration warning days is 7 or more | PASS_WARN_AGE
       lineinfile:
@@ -698,7 +698,7 @@
 
     - name: 5.5.1.3 Ensure password expiration warning days is 7 or more  | chage --warndays
       command: "chage --warndays {{ pass_warn_age }} {{ item }}"
-      loop: "{{ list_of_os_users.split(' ') }}"
+      loop: "{{ list_of_os_users }}"
   ignore_errors: yes
   tags:
     - section5


### PR DESCRIPTION
In the default values, `list_of_users` is defined as a list:
![image](https://github.com/alivx/CIS-Ubuntu-20.04-Ansible/assets/57574705/f55dcd51-da51-4997-9a11-fa2a32c5624e)
And it is used as a list in the task:
![image](https://github.com/alivx/CIS-Ubuntu-20.04-Ansible/assets/57574705/7b1aeb6c-21f1-4418-90b2-e79b673bae70)
However, in tasks 5.5.1.1, 5.5.1.2 and 5.5.1.3, the variable was treated as a string, causing an error during execution:
![image](https://github.com/alivx/CIS-Ubuntu-20.04-Ansible/assets/57574705/32ff3162-5587-4646-b6be-0095fe17b01f)
